### PR TITLE
GDB-5940 Creates a release job for the library

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,0 +1,34 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: Publish package to GitHub Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -37,15 +37,10 @@
 
     <distributionManagement>
         <repository>
-            <id>internal</id>
-            <name>Ontotext Platform Releases repository</name>
-            <url>http://maven.ontotext.com/content/repositories/internal</url>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/ontotext/ontorefine-client</url>
         </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>Ontotext Platform Snapshots repository</name>
-            <url>http://maven.ontotext.com/content/repositories/snapshots</url>
-        </snapshotRepository>
     </distributionManagement>
 
     <properties>


### PR DESCRIPTION
- Added release job via github workflows, which will package and deploy the library in the github package repository, when there is a new release of the library.
- Changed the distribution management in the `pom.xml` in order to configure the workflow correctly as it uses the configurations from the pom file.