### PR TITLE
GDB-5940 Adds changes to related to the release workflow

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -26,9 +26,9 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package -DskipTests --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/ontotext/ontorefine-client</url>
+            <url>https://maven.pkg.github.com/Ontotext-AD/ontorefine-client</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- Changed the URL of the github repository where the package should be
stored.
- Removed the tests execution, when releasing the library as they are
suppose to be running as there is a CI workflow, which will prevent
merging broken tests in the master branch.