### PR TITLE
GDB-5940 Changes to the authentication process of the github release

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/Ontotext-AD/ontorefine-client</url>
+            <url>https://maven.pkg.github.com/Ontotext AD/ontorefine-client</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- Rolledback the usage of the `secret.GITHUB_TOKEN` as variable for the
token.
- Changed the name of the organization for the distribution management
in the pom.