### PR TITLE
GDB-6097 Encodes the name of the organization in the urls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/Ontotext AD/ontorefine-client</url>
+            <url>https://maven.pkg.github.com/Ontotext%20AD/ontorefine-client</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- Our organization name contains `space` in its name so it should be
encoded, when used in URLs.