### PR TITLE
GDB-6097 Removes the creation of the m2 directory

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -30,8 +30,7 @@ jobs:
 
     - name: Publish to GitHub Packages Apache Maven
       run: |
-        mkdir ~/.m2
         echo "<settings><servers><server><id>github</id><username>OWNER</username><password>${GITHUB_TOKEN}</password></server></servers></settings>" > ~/.m2/settings.xml
-        mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        mvn deploy
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Removed the command for the creation of the `.m2` directory as it is
already exists and its breaks the pipeline.