### PR TITLE
GDB-6097 Changes the repository where the package will be released

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,57 @@
+name: Java CI with Maven
+
+# Controls when the action will be run. Triggers the workflow on push or pull request
+# events, but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # TODO: do we need to setup OS matrix to ensure everything is going according to plan
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+      with: 
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevance of analysis
+
+    # Setups the Java version which will be used
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Cache SonarCloud packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.sonar/cache
+        key: ${{ runner.os }}-sonar
+        restore-keys: ${{ runner.os }}-sonar
+
+    - name: Cache Maven packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
+    # Builds the project. The step will perform the following:
+    #  - run unit tests
+    #  - run checkstyle
+    #  - run security scan
+    #  - SonarCloud analyze
+    - name: Build & validate
+      run: mvn -B clean install sonar:sonar
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -1,5 +1,7 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+# Note - The testing and checkstyle phases are disabled, because there is a CI pipeline which guarantees that the master branch is green at all times. Also this will reduce the time for the release process.
+# However the dependency vulnerability check is still on, because there might be Sec-DBs update, between the release an the last CI pipelines.
 
 name: Publish package to GitHub Packages
 
@@ -22,16 +24,16 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        server-username: GITHUB_USER_REF  # env variable name for username
-        server-password: GITHUB_TOKEN_REF # env variable name for GitHub Personal Access Token
+        server-id: all-onto # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: ONTO_MVN_USER_REF
+        server-password: ONTO_MVN_TOKEN_REF
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -B package -DskipTests --file pom.xml
+      run: mvn -B package -DskipTests -Dcheckstyle.skip --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      run: mvn deploy -DskipTests -Dcheckstyle.skip -s $GITHUB_WORKSPACE/settings.xml
       env:
-        GITHUB_USER_REF: ${{ secrets.GH_PACKAGE_REPO_USERNAME }}
-        GITHUB_TOKEN_REF: ${{ secrets.GH_PACKAGE_REPO_PSW }}
+        ONTO_MVN_USER_REF: ${{ secrets.ONTO_MAVEN_REPO_USER }}
+        ONTO_MVN_TOKEN_REF: ${{ secrets.ONTO_MAVEN_REPO_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,9 @@
 
     <distributionManagement>
         <repository>
-            <id>github</id>
-            <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/Ontotext-AD/ontorefine-client</url>
+            <id>all-onto</id>
+            <name>Ontotext Public Maven</name>
+            <url>http://maven.ontotext.com/content/repositories/public</url>
         </repository>
     </distributionManagement>
 
@@ -219,7 +219,7 @@
                         <goals>
                             <goal>aggregate</goal>
                         </goals>
-                        <phase>none</phase>
+                        <phase>verify</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
- Ceased the tries to create a package with the library in the GitHub
repository, because we found out that the upload of packages is disabled
for the organization (it might be related to our payment plan or more
likely the lack of it).
- Changed the repository where the package will be released to our
public Maven.
- Configured the new address for the distribution management in the pom.
- Configured new user and address in the release workflow.
- Reverted the CI workflow.
- Updated the release workflow to skip the tests and the checkstyle,
when packaging and deploying, because the CI pipeline guarantees that
the master is always in green state. Furthermore this will reduce the
time for the release process.