### PR TITLE
GDB-6161 Fixes the command for operations exporting

### DIFF
--- a/src/main/java/com/ontotext/refine/client/command/operations/GetOperationsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/operations/GetOperationsCommand.java
@@ -1,5 +1,6 @@
 package com.ontotext.refine.client.command.operations;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
@@ -7,6 +8,7 @@ import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.HttpParser;
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -49,8 +51,10 @@ public class GetOperationsCommand implements RefineCommand<GetOperationsResponse
   public GetOperationsResponse handleResponse(HttpResponse response) throws IOException {
     HttpParser.HTTP_PARSER.assureStatusCode(response, HttpStatus.SC_OK);
     JsonMapper mapper = new JsonMapper();
+    JsonNode responseJson = mapper.readTree(response.getEntity().getContent());
+    List<JsonNode> operations = responseJson.findValues("operation");
     return new GetOperationsResponse()
-        .setContent(mapper.readTree(response.getEntity().getContent()))
+        .setContent(mapper.createArrayNode().addAll(operations))
         .setProject(project);
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
@@ -1,0 +1,80 @@
+package com.ontotext.refine.client.command;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.RefineClient;
+import java.io.InputStream;
+import java.net.URL;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Provides base common logic that can be used in the concrete command tests.
+ *
+ * @author Antoniy Kunchev
+ */
+public abstract class BaseCommandTest<T, R extends RefineCommand<T>> {
+
+  protected static final String PROJECT_ID = "1234567890987";
+  protected static final String BASE_URI = "http://localhost:1937/";
+
+  @Mock
+  protected RefineClient client;
+
+  /**
+   * Provides the concrete command instance to be used in the tests.
+   *
+   * @return command instance
+   */
+  protected abstract R command();
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+
+    when(client.createUrl(anyString()))
+        .thenAnswer(answer -> new URL(BASE_URI + answer.getArgument(0, String.class)));
+  }
+
+  /**
+   * Provides the base test directory, where the resources for the test are.
+   *
+   * @return path to the directory with test resources
+   */
+  protected String getTestDir() {
+    return "responseBody/";
+  }
+
+  /**
+   * Loads test resource using the {@link #getTestDir()} method to retrieve the directory, where the
+   * resource should be.
+   *
+   * @param resource to be loaded
+   * @return {@link InputStream} of the loaded resource
+   */
+  protected InputStream loadResource(String resource) {
+    return getClass().getClassLoader().getResourceAsStream(getTestDir() + resource);
+  }
+
+  /**
+   * Creates response with status 'OK'.
+   *
+   * @param body for the response
+   * @return HTTP response instance
+   */
+  protected HttpResponse okResponse(InputStream body) {
+    BasicStatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK");
+    BasicHttpEntity entity = new BasicHttpEntity();
+    entity.setContent(body);
+    BasicHttpResponse response = new BasicHttpResponse(statusLine);
+    response.setEntity(entity);
+    return response;
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/operations/GetOperationsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/operations/GetOperationsCommandTest.java
@@ -1,0 +1,68 @@
+package com.ontotext.refine.client.command.operations;
+
+import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link GetOperationsCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class GetOperationsCommandTest
+    extends BaseCommandTest<GetOperationsResponse, GetOperationsCommand> {
+
+  @Override
+  protected GetOperationsCommand command() {
+    return RefineCommands.getOperations().setProject(PROJECT_ID).build();
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "operations/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void execute_failure() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exception =
+        assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Failed to retrieve the operations for project: '" + PROJECT_ID + "' due to: Test error",
+        exception.getMessage());
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void handleResponse_successful() throws IOException {
+    GetOperationsResponse response =
+        command().handleResponse(okResponse(loadResource("getOperations_response.json")));
+
+    JsonNode expected = JSON_PARSER.parseJson(loadResource("getOperations_expected.json"));
+    assertEquals(expected, response.getContent());
+  }
+}

--- a/src/test/resources/operations/getOperations_expected.json
+++ b/src/test/resources/operations/getOperations_expected.json
@@ -1,0 +1,377 @@
+[
+  {
+    "op": "mapping-editor/save-rdf-mapping",
+    "mapping": {
+      "baseIRI": "http://example/base/",
+      "namespaces": {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "schema": "http://schema.org/",
+        "geo": "http://www.opengis.net/ont/geosparql#",
+        "amsterdam": "https://data/amsterdam/nl/resource/",
+        "sf": "http://www.opengis.net/ont/sf#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+      },
+      "subjectMappings": [
+        {
+          "subject": {
+            "valueSource": {
+              "source": "column",
+              "columnName": "Trcid"
+            },
+            "transformation": {
+              "language": "prefix",
+              "expression": "amsterdam:restaurant/"
+            }
+          },
+          "typeMappings": [
+            {
+              "valueSource": {
+                "source": "constant",
+                "constant": "Restaurant"
+              },
+              "transformation": {
+                "language": "prefix",
+                "expression": "schema"
+              }
+            }
+          ],
+          "propertyMappings": [
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "title"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "schema"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Title"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                },
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "TitleEN"
+                  },
+                  "valueType": {
+                    "type": "language_literal",
+                    "language": {
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "en"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "description"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "schema"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Shortdescription"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "latitude"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "schema"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "row_index"
+                  },
+                  "transformation": {
+                    "language": "grel",
+                    "expression": "value.replace(',','.')"
+                  },
+                  "valueType": {
+                    "type": "datatype_literal",
+                    "datatype": {
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "float"
+                      },
+                      "transformation": {
+                        "language": "prefix",
+                        "expression": "xsd"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "zipcode"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "amsterdam"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Zipcode"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "image"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "schema"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Media"
+                  },
+                  "valueType": {
+                    "type": "iri",
+                    "typeMappings": [],
+                    "propertyMappings": []
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "hasGeometry"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "geo"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Trcid"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "amsterdam:geometry/"
+                  },
+                  "valueType": {
+                    "type": "iri",
+                    "typeMappings": [
+                      {
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "Point"
+                        },
+                        "transformation": {
+                          "language": "prefix",
+                          "expression": "sf"
+                        }
+                      }
+                    ],
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "asWKT"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "geo"
+                          }
+                        },
+                        "values": [
+                          {
+                            "valueSource": {
+                              "source": "row_index"
+                            },
+                            "transformation": {
+                              "language": "grel",
+                              "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\""
+                            },
+                            "valueType": {
+                              "type": "datatype_literal",
+                              "datatype": {
+                                "valueSource": {
+                                  "source": "constant",
+                                  "constant": "wktLiteral"
+                                },
+                                "transformation": {
+                                  "language": "prefix",
+                                  "expression": "geo"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "uniquelocation"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "amsterdam"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Trcid"
+                  },
+                  "valueType": {
+                    "type": "unique_bnode",
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "address"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "amsterdam"
+                          }
+                        },
+                        "values": [
+                          {
+                            "valueSource": {
+                              "source": "column",
+                              "columnName": "Adres"
+                            },
+                            "valueType": {
+                              "type": "literal"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "valuelocation"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "amsterdam"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "source": "column",
+                    "columnName": "Trcid"
+                  },
+                  "valueType": {
+                    "type": "value_bnode",
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "city"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "amsterdam"
+                          }
+                        },
+                        "values": [
+                          {
+                            "valueSource": {
+                              "source": "column",
+                              "columnName": "City"
+                            },
+                            "valueType": {
+                              "type": "literal"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF Mapping"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "City",
+    "expression": "value.toTitlecase()",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column City using expression value.toTitlecase()"
+  }
+]

--- a/src/test/resources/operations/getOperations_response.json
+++ b/src/test/resources/operations/getOperations_response.json
@@ -1,0 +1,385 @@
+{
+  "entries": [
+    {
+      "description": "Save RDF Mapping",
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example/base/",
+          "namespaces": {
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "schema": "http://schema.org/",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "amsterdam": "https://data/amsterdam/nl/resource/",
+            "sf": "http://www.opengis.net/ont/sf#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+          },
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "column",
+                  "columnName": "Trcid"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "amsterdam:restaurant/"
+                }
+              },
+              "typeMappings": [
+                {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "Restaurant"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                }
+              ],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    },
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "TitleEN"
+                      },
+                      "valueType": {
+                        "type": "language_literal",
+                        "language": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "en"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "description"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Shortdescription"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "latitude"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "row_index"
+                      },
+                      "transformation": {
+                        "language": "grel",
+                        "expression": "value.replace(',','.')"
+                      },
+                      "valueType": {
+                        "type": "datatype_literal",
+                        "datatype": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "float"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "xsd"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "zipcode"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Zipcode"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "image"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Media"
+                      },
+                      "valueType": {
+                        "type": "iri",
+                        "typeMappings": [],
+                        "propertyMappings": []
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "hasGeometry"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "geo"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "transformation": {
+                        "language": "prefix",
+                        "expression": "amsterdam:geometry/"
+                      },
+                      "valueType": {
+                        "type": "iri",
+                        "typeMappings": [
+                          {
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "Point"
+                            },
+                            "transformation": {
+                              "language": "prefix",
+                              "expression": "sf"
+                            }
+                          }
+                        ],
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "asWKT"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "geo"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "row_index"
+                                },
+                                "transformation": {
+                                  "language": "grel",
+                                  "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\""
+                                },
+                                "valueType": {
+                                  "type": "datatype_literal",
+                                  "datatype": {
+                                    "valueSource": {
+                                      "source": "constant",
+                                      "constant": "wktLiteral"
+                                    },
+                                    "transformation": {
+                                      "language": "prefix",
+                                      "expression": "geo"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "uniquelocation"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "valueType": {
+                        "type": "unique_bnode",
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "address"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "amsterdam"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "column",
+                                  "columnName": "Adres"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "valuelocation"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "valueType": {
+                        "type": "value_bnode",
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "city"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "amsterdam"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "column",
+                                  "columnName": "City"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      }
+    },
+    {
+      "description": "Text transform on 725 cells in column City: value.toTitlecase()",
+      "operation": {
+        "op": "core/text-transform",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "columnName": "City",
+        "expression": "value.toTitlecase()",
+        "onError": "keep-original",
+        "repeat": false,
+        "repeatCount": 10,
+        "description": "Text transform on cells in column City using expression value.toTitlecase()"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- The issue with the command was that the returned JSON from the Refine
tool was containing additional tags and operation wrapping objects,
which causes failure if a client tries to use the JSON directly in the
apply operations command.

Apparently there is an additional processing of the JSON in the UI in
the export window, which is the reason the exported JSONs were
different.

To fix the issue we are processing the response from the Refine tool by
extracting all of the objects which are under `operation` tag and
collect them in a new array, which is then returned as result from the
operation.
- Added tests to verify the behavior of the command and the changes that
were added.