### PR TITLE
GDB-6170 Adds additional parameter to the export RDF command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Ontotext OntoRefine Client Library
 
-## Version 0.1.0
+## Version 1.1.0
+
+ - Fixed the issue where the export operation command resulted in JSON, which cannot be used directly in apply operation command as it was containing additional tags and wrapping
+   of the main operation objects, which should be returned as result.
+ - Added additional required parameter to the export RDF command called `format`. It is used to build `Accept` header for the request that is sent to the OntoRefine tool. The
+   header is used to show in what RDF format should be returned the result from the command. For example `Turtle`, `Turtle-Star`, `N-Triples`, `RDF/XML`, etc.
+
+
+## Version 1.0.0
 
 ### Initial work
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.io.version>2.10.0</commons.io.version>
         <jackson.databind.version>2.12.4</jackson.databind.version>
+        <rdf4j.version>3.7.2</rdf4j.version>
 
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito.version>3.8.0</mockito.version>
@@ -113,6 +114,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.databind.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-repository-api</artifactId>
+            <version>${rdf4j.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
@@ -1,0 +1,50 @@
+package com.ontotext.refine.client.command.rdf;
+
+import org.eclipse.rdf4j.rio.RDFFormat;
+
+/**
+ * Contains values for the result format of the {@link ExportRdfCommand}. Basically it is a proxy
+ * for the {@link RDFFormat} values, which decouples the 'RDF4J' dependency from the client.
+ *
+ * @author Antoniy Kunchev
+ */
+public enum ResultFormat {
+
+  RDFXML(RDFFormat.RDFXML),
+
+  NTRIPLES(RDFFormat.NTRIPLES),
+
+  TURTLE(RDFFormat.TURTLE),
+
+  TURTLESTAR(RDFFormat.TURTLESTAR),
+
+  N3(RDFFormat.N3),
+
+  TRIX(RDFFormat.TRIX),
+
+  TRIG(RDFFormat.TRIG),
+
+  TRIGSTAR(RDFFormat.TRIGSTAR),
+
+  BINARY(RDFFormat.BINARY),
+
+  NQUADS(RDFFormat.NQUADS),
+
+  JSONLD(RDFFormat.JSONLD),
+
+  RDFJSON(RDFFormat.RDFJSON),
+
+  RDFA(RDFFormat.RDFA),
+
+  HDT(RDFFormat.HDT);
+
+  private final RDFFormat rdfFormat;
+
+  private ResultFormat(RDFFormat format) {
+    this.rdfFormat = format;
+  }
+
+  public RDFFormat getRdfFormat() {
+    return rdfFormat;
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
@@ -44,7 +44,8 @@ public abstract class BaseCommandTest<T, R extends RefineCommand<T>> {
   }
 
   /**
-   * Provides the base test directory, where the resources for the test are.
+   * Provides the base test directory, where the resources for the test are. By default this method
+   * returns 'responseBody/' as value.
    *
    * @return path to the directory with test resources
    */

--- a/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
@@ -1,0 +1,92 @@
+package com.ontotext.refine.client.command.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+/**
+ * Test for {@link ExportRdfCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, ExportRdfCommand> {
+
+  @Captor
+  private ArgumentCaptor<HttpUriRequest> requestCaptor;
+
+  private String mapping;
+
+  @BeforeEach
+  void init() throws IOException {
+    mapping = IOUtils.toString(loadResource("getOperations_response.json"), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected ExportRdfCommand command() {
+    return RefineCommands.exportRdf()
+        .setProject(PROJECT_ID)
+        .setMapping(mapping)
+        .setFormat(ResultFormat.TURTLE)
+        .build();
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "rdf/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(requestCaptor.capture(), any());
+
+    HttpUriRequest request = requestCaptor.getValue();
+
+    assertEquals(
+        "text/turtle;charset=UTF-8",
+        request.getFirstHeader(HttpHeaders.ACCEPT).getValue());
+  }
+
+  @Test
+  void execute_failure() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exc = assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Export of RDF data failed for project: '" + PROJECT_ID + "' due to: Test error",
+        exc.getMessage());
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void handleResponse() throws IOException {
+    try (InputStream is = new ByteArrayInputStream("dummy RDF data".getBytes())) {
+      ExportRdfResponse response = command().handleResponse(okResponse(is));
+      assertEquals("dummy RDF data", response.getResult());
+    }
+  }
+}

--- a/src/test/resources/rdf/getOperations_response.json
+++ b/src/test/resources/rdf/getOperations_response.json
@@ -1,0 +1,385 @@
+{
+  "entries": [
+    {
+      "description": "Save RDF Mapping",
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example/base/",
+          "namespaces": {
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "schema": "http://schema.org/",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "amsterdam": "https://data/amsterdam/nl/resource/",
+            "sf": "http://www.opengis.net/ont/sf#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+          },
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "column",
+                  "columnName": "Trcid"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "amsterdam:restaurant/"
+                }
+              },
+              "typeMappings": [
+                {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "Restaurant"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                }
+              ],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    },
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "TitleEN"
+                      },
+                      "valueType": {
+                        "type": "language_literal",
+                        "language": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "en"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "description"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Shortdescription"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "latitude"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "row_index"
+                      },
+                      "transformation": {
+                        "language": "grel",
+                        "expression": "value.replace(',','.')"
+                      },
+                      "valueType": {
+                        "type": "datatype_literal",
+                        "datatype": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "float"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "xsd"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "zipcode"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Zipcode"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "image"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "schema"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Media"
+                      },
+                      "valueType": {
+                        "type": "iri",
+                        "typeMappings": [],
+                        "propertyMappings": []
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "hasGeometry"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "geo"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "transformation": {
+                        "language": "prefix",
+                        "expression": "amsterdam:geometry/"
+                      },
+                      "valueType": {
+                        "type": "iri",
+                        "typeMappings": [
+                          {
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "Point"
+                            },
+                            "transformation": {
+                              "language": "prefix",
+                              "expression": "sf"
+                            }
+                          }
+                        ],
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "asWKT"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "geo"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "row_index"
+                                },
+                                "transformation": {
+                                  "language": "grel",
+                                  "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\""
+                                },
+                                "valueType": {
+                                  "type": "datatype_literal",
+                                  "datatype": {
+                                    "valueSource": {
+                                      "source": "constant",
+                                      "constant": "wktLiteral"
+                                    },
+                                    "transformation": {
+                                      "language": "prefix",
+                                      "expression": "geo"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "uniquelocation"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "valueType": {
+                        "type": "unique_bnode",
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "address"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "amsterdam"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "column",
+                                  "columnName": "Adres"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "valuelocation"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Trcid"
+                      },
+                      "valueType": {
+                        "type": "value_bnode",
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "city"
+                              },
+                              "transformation": {
+                                "language": "prefix",
+                                "expression": "amsterdam"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "source": "column",
+                                  "columnName": "City"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      }
+    },
+    {
+      "description": "Text transform on 725 cells in column City: value.toTitlecase()",
+      "operation": {
+        "op": "core/text-transform",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "columnName": "City",
+        "expression": "value.toTitlecase()",
+        "onError": "keep-original",
+        "repeat": false,
+        "repeatCount": 10,
+        "description": "Text transform on cells in column City using expression value.toTitlecase()"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Added new required parameter to the `ExportRdfCommand`, which is used
to build `Accept` header for the request that is sent to the OntoRefine
tool. By using this header the client can control the return format of
the result RDF, which will be returned as response from the command.

Additionally it will allow us to provide this option to the CLI tool,
which will fix the related issue.
- Added tests for the command to verify the correct behavior.