### PR TITLE
GDB-6169 Introduces new command for retrieval of the models of a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
    of the main operation objects, which should be returned as result.
  - Added additional required parameter to the export RDF command called `format`. It is used to build `Accept` header for the request that is sent to the OntoRefine tool. The
    header is used to show in what RDF format should be returned the result from the command. For example `Turtle`, `Turtle-Star`, `N-Triples`, `RDF/XML`, etc.
+ - Introduced new command which allows retrieval of the models of specific project. It provides temporary workaround for the issue with the RDF mapping, where after update it won't
+   be synchronized with the JSON configuration for the operations done over the project. We were using the mapping from the operations in the RDF exporting. 
 
 
 ## Version 1.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.1-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An OntoRefine Client Library</description>

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
@@ -17,6 +17,7 @@ package com.ontotext.refine.client.command;
 import com.ontotext.refine.client.command.create.CreateProjectCommand;
 import com.ontotext.refine.client.command.csrf.GetCsrfTokenCommand;
 import com.ontotext.refine.client.command.delete.DeleteProjectCommand;
+import com.ontotext.refine.client.command.models.GetProjectModelsCommand;
 import com.ontotext.refine.client.command.operations.ApplyOperationsCommand;
 import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.command.processes.GetProcessesCommand;
@@ -132,7 +133,7 @@ public interface RefineCommands {
 
   /**
    * Provides a builder instance for the {@link GetProcessesCommand}.
-   * 
+   *
    * @return new builder instance
    */
   static GetProcessesCommand.Builder getProcesses() {
@@ -141,10 +142,19 @@ public interface RefineCommands {
 
   /**
    * Provides a builder instance for the {@link ReconcileCommand}.
-   * 
+   *
    * @return new builder instance
    */
   static ReconcileCommand.Builder reconcile() {
     return new ReconcileCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link GetProjectModelsCommand}.
+   *
+   * @return new builder instance
+   */
+  static GetProjectModelsCommand.Builder getProjectModels() {
+    return new GetProjectModelsCommand.Builder();
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsCommand.java
@@ -1,0 +1,80 @@
+package com.ontotext.refine.client.command.models;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import com.ontotext.refine.client.util.HttpParser;
+import java.io.IOException;
+import java.net.URL;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+
+/**
+ * A command that retrieves the models for specified project.
+ *
+ * @author Antoniy Kunchev
+ */
+public class GetProjectModelsCommand implements RefineCommand<GetProjectModelsResponse> {
+
+  private final String project;
+
+  private GetProjectModelsCommand(String project) {
+    this.project = project;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/orefine/command/core/get-models";
+  }
+
+  @Override
+  public GetProjectModelsResponse execute(RefineClient client) throws RefineException {
+    try {
+      URL url = client.createUrl(endpoint());
+      HttpUriRequest request =
+          RequestBuilder.get(url.toString()).addParameter(Constants.PROJECT, project).build();
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      throw new RefineException(
+          "Failed to retrieve the models for project: '%s' due to: %s",
+          project,
+          ioe.getMessage());
+    }
+  }
+
+  @Override
+  public GetProjectModelsResponse handleResponse(HttpResponse response) throws IOException {
+    HttpParser.HTTP_PARSER.assureStatusCode(response, HttpStatus.SC_OK);
+    return new JsonMapper()
+        .readValue(response.getEntity().getContent(), GetProjectModelsResponse.class);
+  }
+
+  /**
+   * Builder for {@link GetProjectModelsCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String project;
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    /**
+     * Builds the {@link GetProjectModelsCommand}.
+     *
+     * @return a command
+     */
+    public GetProjectModelsCommand build() {
+      Validate.notBlank(project, "Missing 'project' argument");
+      return new GetProjectModelsCommand(project);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsResponse.java
@@ -1,0 +1,57 @@
+package com.ontotext.refine.client.command.models;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Holds the response from {@link GetProjectModelsCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+public class GetProjectModelsResponse {
+
+  private JsonNode columnModel;
+  private JsonNode httpHeaders;
+  private JsonNode overlayModels;
+  private JsonNode recordModel;
+  private JsonNode scripting;
+
+  public JsonNode getColumnModel() {
+    return columnModel;
+  }
+
+  public void setColumnModel(JsonNode columnModel) {
+    this.columnModel = columnModel;
+  }
+
+  public JsonNode getHttpHeaders() {
+    return httpHeaders;
+  }
+
+  public void setHttpHeaders(JsonNode httpHeaders) {
+    this.httpHeaders = httpHeaders;
+  }
+
+  public JsonNode getOverlayModels() {
+    return overlayModels;
+  }
+
+  public void setOverlayModels(JsonNode overlayModels) {
+    this.overlayModels = overlayModels;
+  }
+
+  public JsonNode getRecordModel() {
+    return recordModel;
+  }
+
+  public void setRecordModel(JsonNode recordModel) {
+    this.recordModel = recordModel;
+  }
+
+  public JsonNode getScripting() {
+    return scripting;
+  }
+
+  public void setScripting(JsonNode scripting) {
+    this.scripting = scripting;
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/models/GetProjectModelsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/models/GetProjectModelsCommandTest.java
@@ -1,0 +1,67 @@
+package com.ontotext.refine.client.command.models;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link GetProjectModelsCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class GetProjectModelsCommandTest
+    extends BaseCommandTest<GetProjectModelsResponse, GetProjectModelsCommand> {
+
+  @Override
+  protected GetProjectModelsCommand command() {
+    return RefineCommands.getProjectModels().setProject(PROJECT_ID).build();
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "project-models/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void execute_failure() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    assertThrows(RefineException.class, () -> command().execute(client));
+
+    verify(client).createUrl(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void handleResponse() throws IOException {
+    InputStream body = loadResource("getProjectModels_response.json");
+
+    GetProjectModelsResponse response = command().handleResponse(okResponse(body));
+
+    assertNotNull(response);
+    assertNotNull(response.getColumnModel());
+    assertNotNull(response.getHttpHeaders());
+    assertNotNull(response.getOverlayModels());
+    assertNotNull(response.getRecordModel());
+    assertNotNull(response.getScripting());
+  }
+}

--- a/src/test/resources/project-models/getProjectModels_response.json
+++ b/src/test/resources/project-models/getProjectModels_response.json
@@ -1,0 +1,658 @@
+{
+  "columnModel": {
+    "columns": [
+      {
+        "cellIndex": 0,
+        "originalName": "Trcid",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Trcid"
+      },
+      {
+        "cellIndex": 1,
+        "originalName": "Title",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Title"
+      },
+      {
+        "cellIndex": 2,
+        "originalName": "Shortdescription",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Shortdescription"
+      },
+      {
+        "cellIndex": 3,
+        "originalName": "Longdescription",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Longdescription"
+      },
+      {
+        "cellIndex": 4,
+        "originalName": "Calendarsummary",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Calendarsummary"
+      },
+      {
+        "cellIndex": 5,
+        "originalName": "TitleEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "TitleEN"
+      },
+      {
+        "cellIndex": 6,
+        "originalName": "ShortdescriptionEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "ShortdescriptionEN"
+      },
+      {
+        "cellIndex": 7,
+        "originalName": "LongdescriptionEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "LongdescriptionEN"
+      },
+      {
+        "cellIndex": 8,
+        "originalName": "CalendarsummaryEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "CalendarsummaryEN"
+      },
+      {
+        "cellIndex": 9,
+        "originalName": "Types",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Types"
+      },
+      {
+        "cellIndex": 10,
+        "originalName": "Ids",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Ids"
+      },
+      {
+        "cellIndex": 11,
+        "originalName": "Locatienaam",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Locatienaam"
+      },
+      {
+        "cellIndex": 12,
+        "originalName": "City",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "City"
+      },
+      {
+        "cellIndex": 13,
+        "originalName": "Adres",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Adres"
+      },
+      {
+        "cellIndex": 14,
+        "originalName": "Zipcode",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Zipcode"
+      },
+      {
+        "cellIndex": 15,
+        "originalName": "Latitude",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Latitude"
+      },
+      {
+        "cellIndex": 16,
+        "originalName": "Longitude",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Longitude"
+      },
+      {
+        "cellIndex": 17,
+        "originalName": "Urls",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Urls"
+      },
+      {
+        "cellIndex": 18,
+        "originalName": "Media",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Media"
+      },
+      {
+        "cellIndex": 19,
+        "originalName": "Thumbnail",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Thumbnail"
+      },
+      {
+        "cellIndex": 20,
+        "originalName": "Datepattern_startdate",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Datepattern_startdate"
+      },
+      {
+        "cellIndex": 21,
+        "originalName": "Datepattern_enddate",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Datepattern_enddate"
+      },
+      {
+        "cellIndex": 22,
+        "originalName": "Singledates",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Singledates"
+      },
+      {
+        "cellIndex": 23,
+        "originalName": "Type1",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Type1"
+      },
+      {
+        "cellIndex": 24,
+        "originalName": "Lastupdated",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Lastupdated"
+      },
+      {
+        "cellIndex": 25,
+        "originalName": "Column",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Column"
+      }
+    ],
+    "columnGroups": [],
+    "keyCellIndex": 0,
+    "keyColumnName": "Trcid"
+  },
+  "recordModel": {
+    "hasRecords": false
+  },
+  "overlayModels": {
+    "mappingDefinition": {
+      "mappingDefinition": {
+        "baseIRI": "http://example/base/",
+        "namespaces": {
+          "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          "schema": "http://schema.org/",
+          "geo": "http://www.opengis.net/ont/geosparql#",
+          "amsterdam": "https://data/amsterdam/nl/resource/",
+          "sf": "http://www.opengis.net/ont/sf#",
+          "xsd": "http://www.w3.org/2001/XMLSchema#",
+          "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "column",
+                "columnName": "Trcid"
+              },
+              "transformation": {
+                "language": "prefix",
+                "expression": "amsterdam:restaurant/"
+              }
+            },
+            "typeMappings": [
+              {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "Restaurant"
+                },
+                "transformation": {
+                  "language": "prefix",
+                  "expression": "schema"
+                }
+              }
+            ],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Title"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  },
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "TitleEN"
+                    },
+                    "valueType": {
+                      "type": "language_literal",
+                      "language": {
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "en"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "description"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Shortdescription"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "latitude"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "row_index"
+                    },
+                    "transformation": {
+                      "language": "grel",
+                      "expression": "value.replace(',','.')"
+                    },
+                    "valueType": {
+                      "type": "datatype_literal",
+                      "datatype": {
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "float"
+                        },
+                        "transformation": {
+                          "language": "prefix",
+                          "expression": "xsd"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "zipcode"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "amsterdam"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Zipcode"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "image"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "schema"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Media"
+                    },
+                    "valueType": {
+                      "type": "iri",
+                      "typeMappings": [],
+                      "propertyMappings": []
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "hasGeometry"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "geo"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Trcid"
+                    },
+                    "transformation": {
+                      "language": "prefix",
+                      "expression": "amsterdam:geometry/"
+                    },
+                    "valueType": {
+                      "type": "iri",
+                      "typeMappings": [
+                        {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "Point"
+                          },
+                          "transformation": {
+                            "language": "prefix",
+                            "expression": "sf"
+                          }
+                        }
+                      ],
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "asWKT"
+                            },
+                            "transformation": {
+                              "language": "prefix",
+                              "expression": "geo"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "source": "row_index"
+                              },
+                              "transformation": {
+                                "language": "grel",
+                                "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\""
+                              },
+                              "valueType": {
+                                "type": "datatype_literal",
+                                "datatype": {
+                                  "valueSource": {
+                                    "source": "constant",
+                                    "constant": "wktLiteral"
+                                  },
+                                  "transformation": {
+                                    "language": "prefix",
+                                    "expression": "geo"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "uniquelocation"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "amsterdam"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Trcid"
+                    },
+                    "valueType": {
+                      "type": "unique_bnode",
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "address"
+                            },
+                            "transformation": {
+                              "language": "prefix",
+                              "expression": "amsterdam"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "source": "column",
+                                "columnName": "Adres"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "valuelocation"
+                  },
+                  "transformation": {
+                    "language": "prefix",
+                    "expression": "amsterdam"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "Trcid"
+                    },
+                    "valueType": {
+                      "type": "value_bnode",
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "city"
+                            },
+                            "transformation": {
+                              "language": "prefix",
+                              "expression": "amsterdam"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "source": "column",
+                                "columnName": "City"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "scripting": {
+    "grel": {
+      "name": "General Refine Expression Language (GREL)",
+      "defaultExpression": "value"
+    },
+    "clojure": {
+      "name": "Clojure",
+      "defaultExpression": "value"
+    }
+  },
+  "httpHeaders": {
+    "authorization": {
+      "header": "Authorization",
+      "defaultValue": ""
+    },
+    "user-agent": {
+      "header": "User-Agent",
+      "defaultValue": "OpenRefine 2.6 [1]"
+    },
+    "accept": {
+      "header": "Accept",
+      "defaultValue": "*/*"
+    }
+  }
+}


### PR DESCRIPTION
- Introduced new command, which allows retrieval of the models for
specified project identifier. It will allow us to get the correct RDF
mapping after update, because there is an issue with the mapping stored
in the operations configuration. After update of the mapping in the
`mapping UI`, the changes aren't synchronized in the operations
configuration and they remain stale.
- Added test for the new command.
- Bumped the version of the project to new development version.