### PR TITLE
Updates the library to the new development version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Ontotext OntoRefine Client Library
 
+## Version 1.3
+
+### New
+
+### Changes
+
+### Bug fixes
+
+
 ## Version 1.2
 
 ### New

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.3-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An OntoRefine Client Library</description>

--- a/src/test/java/com/ontotext/refine/client/CommandIntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/CommandIntegrationTest.java
@@ -21,6 +21,8 @@ import org.testcontainers.shaded.org.awaitility.Awaitility;
  */
 public abstract class CommandIntegrationTest extends IntegrationTest {
 
+  private static final long WAIT_FOR_PROCESSES = 20;
+
   /**
    * Provides CSRF tokens, retrieved from OntoRefine tool.
    *
@@ -57,14 +59,14 @@ public abstract class CommandIntegrationTest extends IntegrationTest {
   /**
    * Waits until all processes (if any) are completed for the given project. The method will pull
    * the processes that are currently executed from the OntoRefine for the project every
-   * {@value #WAIT_FOR_PROCESSES} ms until there are no processes returned.
+   * {@value #WAIT_FOR_PROCESSES} seconds until there are no processes returned.
    *
    * @param projectId which processes should be completed
    */
   protected void waitForProcessesCompletion(String projectId) throws RefineException {
     GetProcessesCommand command = RefineCommands.getProcesses().setProject(projectId).build();
     Awaitility.await()
-        .atMost(10, TimeUnit.SECONDS)
+        .atMost(WAIT_FOR_PROCESSES, TimeUnit.SECONDS)
         .until(() -> command.execute(getClient()).getProcesses().isEmpty());
   }
 

--- a/src/test/java/com/ontotext/refine/client/IntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/IntegrationTest.java
@@ -20,8 +20,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 public abstract class IntegrationTest {
 
-  private static final String DEFAUL_GDB_DOCKER_IMAGE =
-      "docker-registry.ontotext.com/graphdb-free:9.9.0-adoptopenjdk11";
+  private static final String DEFAUL_GDB_DOCKER_IMAGE = "ontotext/graphdb:9.10.0-ee";
 
   // Tries to retrieve the image name from the surefire plugin property. Otherwise uses the default
   private static final DockerImageName GDB_DOCKER_IMAGE_NAME =


### PR DESCRIPTION
- Changed the version in the `pom.xml` to the `1.3-SNAPSHOT` from
`1.2.0`.
- Added new section `Version 1.3` to the `CHANGELOG.md` document.
- Increased the waiting timeout for the running processes check in
`OntoRefine` for the integration tests.