### PR TITLE
GDB-6143 Changes the object used for endpoint creation from URL to URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
    additional information to the different commands.
  - Moved the `ExportRowsCommand` in its own package in order to keep the structure of the project consistent. Updated the command to comply with the new definition of the
    commands.
+ - Changed the object that is used for creation of the full endpoint address from `URL` to `URI`, which can be passed directly to the request builders without the need of
+   converting it to `String`. 
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ complete given operation.
  <dependency>
      <groupId>com.ontotext</groupId>
      <artifactId>ontorefine-client</artifactId>
-     <version>1.2.0</version>
+     <version>1.3.0</version>
  </dependency>
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 
 ## Minor
 
-- Change the building of the Refine instance address. Instead of URL, we can use URI and directly provide it to the request builders
 - Refactor the project metadata retrieving command to implement the new definition.
 - Think of a way to separate the commands in the `RefineCommands` interface by some common classifier. For example `project`, `reconciliation`, `preferences`, etc.
 - Remove the unit tests, which are duplicating the integration tests as there are redundant. We need to use unit tests only for commands input verification or error handling.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.3-SNAPSHOT</version>
+    <version>1.3.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An OntoRefine Client Library</description>

--- a/src/main/java/com/ontotext/refine/client/RefineClient.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClient.java
@@ -1,11 +1,11 @@
 package com.ontotext.refine.client;
 
-import java.io.Closeable;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 
@@ -13,33 +13,33 @@ import org.apache.http.impl.client.CloseableHttpClient;
  * Represents the client which purpose is to provide the HTTP communication between the application
  * and the Refine instance.
  */
-public class RefineClient implements Closeable {
+public class RefineClient implements AutoCloseable {
 
-  private final URL url;
+  private final URI uri;
   private final CloseableHttpClient httpClient;
 
   /**
    * Creates new client instance.
    *
-   * @param url where the Refine instance could be accessed
+   * @param uri where the Refine instance could be accessed
    * @param httpClient used to executed the requests
    */
-  RefineClient(URL url, CloseableHttpClient httpClient) {
-    this.url = url;
+  RefineClient(URI uri, CloseableHttpClient httpClient) {
+    this.uri = uri;
     this.httpClient = httpClient;
   }
 
   /**
-   * Creates URL from the provided path and the base URL of the current client.
+   * Creates URI from the provided path and the base URI of the current client.
    *
-   * @param path to be added to the base URL
-   * @return new {@link URL}
+   * @param path to be added to the base URI
+   * @return new {@link URI}
    */
-  public URL createUrl(String path) {
+  public URI createUri(String path) {
     try {
-      return new URL(url, path);
-    } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(e);
+      return new URIBuilder(uri).setPath(path).build();
+    } catch (URISyntaxException uriExc) {
+      throw new IllegalArgumentException(uriExc);
     }
   }
 
@@ -58,12 +58,12 @@ public class RefineClient implements Closeable {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close() throws Exception {
     httpClient.close();
   }
 
   @Override
   public String toString() {
-    return "RefineClient{" + "url=" + url + '}';
+    return "RefineClient{" + "url=" + uri + '}';
   }
 }

--- a/src/main/java/com/ontotext/refine/client/RefineClients.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClients.java
@@ -1,13 +1,13 @@
 package com.ontotext.refine.client;
 
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.apache.http.impl.client.HttpClients;
 
 public interface RefineClients {
 
-  static RefineClient create(String url) throws MalformedURLException {
+  static RefineClient create(String uri) throws URISyntaxException {
     // TODO configure some sensible timeouts and other configurations
-    return new RefineClient(new URL(url), HttpClients.createDefault());
+    return new RefineClient(new URI(uri), HttpClients.createDefault());
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/ExpressionPreviewCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/ExpressionPreviewCommand.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,9 +78,9 @@ public class ExpressionPreviewCommand implements RefineCommand<ExpressionPreview
       form.add(new BasicNameValuePair("repeat", String.valueOf(repeat)));
       form.add(new BasicNameValuePair("repeatCount", String.valueOf(repeatCount)));
 
-      URL url = client.createUrl(endpoint() + "?" + Constants.CSRF_TOKEN_PARAM + token);
       HttpUriRequest request = RequestBuilder
-          .post(url.toString())
+          .post(client.createUri(endpoint()))
+          .addParameter(Constants.CSRF_TOKEN, token)
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .setEntity(new UrlEncodedFormEntity(form, Consts.UTF_8))
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/GetProjectMetadataCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/GetProjectMetadataCommand.java
@@ -38,7 +38,7 @@ public class GetProjectMetadataCommand implements RefineCommand<GetProjectMetada
   public GetProjectMetadataResponse execute(RefineClient client) throws RefineException {
     try {
       HttpUriRequest request = RequestBuilder
-          .get(client.createUrl(endpoint()).toString())
+          .get(client.createUri(endpoint()))
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .addParameter(new BasicNameValuePair("project", projectId))
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommand.java
@@ -38,10 +38,7 @@ public interface RefineCommand<T> extends ResponseHandler<T> {
   class Constants {
 
     public static final String PROJECT = "project";
-    public static final String PROJECT_PARAM = PROJECT + "=";
-
     public static final String CSRF_TOKEN = "csrf_token";
-    public static final String CSRF_TOKEN_PARAM = CSRF_TOKEN + "=";
 
     private Constants() {
       // utility

--- a/src/main/java/com/ontotext/refine/client/command/csrf/GetCsrfTokenCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/csrf/GetCsrfTokenCommand.java
@@ -11,7 +11,6 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -37,10 +36,8 @@ public class GetCsrfTokenCommand implements RefineCommand<GetCsrfTokenResponse> 
   @Override
   public GetCsrfTokenResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint());
-
       HttpUriRequest request = RequestBuilder
-          .get(url.toString())
+          .get(client.createUri(endpoint()))
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .build();
 

--- a/src/main/java/com/ontotext/refine/client/command/delete/DeleteProjectCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/delete/DeleteProjectCommand.java
@@ -1,6 +1,5 @@
 package com.ontotext.refine.client.command.delete;
 
-import static com.ontotext.refine.client.command.RefineCommand.Constants.CSRF_TOKEN_PARAM;
 import static com.ontotext.refine.client.util.HttpParser.HTTP_PARSER;
 import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
 import static java.util.Collections.singletonList;
@@ -14,8 +13,7 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
-import org.apache.http.Consts;
+import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -51,13 +49,12 @@ public class DeleteProjectCommand implements RefineCommand<DeleteProjectResponse
   @Override
   public DeleteProjectResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint() + "?" + CSRF_TOKEN_PARAM + token);
-
       UrlEncodedFormEntity entity = new UrlEncodedFormEntity(
-          singletonList(new BasicNameValuePair("project", projectId)), Consts.UTF_8);
+          singletonList(new BasicNameValuePair("project", projectId)), StandardCharsets.UTF_8);
 
       HttpUriRequest request = RequestBuilder
-          .post(url.toString())
+          .post(client.createUri(endpoint()))
+          .addParameter(Constants.CSRF_TOKEN, token)
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .setEntity(entity)
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/export/ExportRowsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/export/ExportRowsCommand.java
@@ -64,7 +64,7 @@ public class ExportRowsCommand implements RefineCommand<ExportRowsResponse> {
       List<NameValuePair> form = buildForm();
 
       HttpUriRequest request = RequestBuilder
-          .post(client.createUrl(endpoint()).toString())
+          .post(client.createUri(endpoint()))
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .setEntity(new UrlEncodedFormEntity(form, UTF_8))
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/models/GetProjectModelsCommand.java
@@ -6,7 +6,7 @@ import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.HttpParser;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -34,9 +34,9 @@ public class GetProjectModelsCommand implements RefineCommand<GetProjectModelsRe
   @Override
   public GetProjectModelsResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint());
+      URI uri = client.createUri(endpoint());
       HttpUriRequest request =
-          RequestBuilder.get(url.toString()).addParameter(Constants.PROJECT, project).build();
+          RequestBuilder.get(uri).addParameter(Constants.PROJECT, project).build();
       return client.execute(request, this);
     } catch (IOException ioe) {
       throw new RefineException(

--- a/src/main/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommand.java
@@ -1,6 +1,5 @@
 package com.ontotext.refine.client.command.operations;
 
-import static com.ontotext.refine.client.command.RefineCommand.Constants.CSRF_TOKEN_PARAM;
 import static com.ontotext.refine.client.util.HttpParser.HTTP_PARSER;
 import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
 import static org.apache.commons.lang3.StringUtils.appendIfMissing;
@@ -19,7 +18,6 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,8 +62,6 @@ public class ApplyOperationsCommand implements RefineCommand<ApplyOperationsResp
   @Override
   public ApplyOperationsResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint() + "?" + CSRF_TOKEN_PARAM + token);
-
       List<NameValuePair> form = new ArrayList<>(2);
       form.add(new BasicNameValuePair(Constants.PROJECT, projectId));
 
@@ -77,7 +73,8 @@ public class ApplyOperationsCommand implements RefineCommand<ApplyOperationsResp
       UrlEncodedFormEntity entity = new UrlEncodedFormEntity(form, Consts.UTF_8);
 
       HttpUriRequest request = RequestBuilder
-          .post(url.toString())
+          .post(client.createUri(endpoint()))
+          .addParameter(Constants.CSRF_TOKEN, token)
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .setEntity(entity)
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/operations/GetOperationsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/operations/GetOperationsCommand.java
@@ -1,5 +1,7 @@
 package com.ontotext.refine.client.command.operations;
 
+import static com.ontotext.refine.client.command.RefineCommand.Constants.PROJECT;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.ontotext.refine.client.RefineClient;
@@ -7,11 +9,11 @@ import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.HttpParser;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 
 
@@ -36,8 +38,9 @@ public class GetOperationsCommand implements RefineCommand<GetOperationsResponse
   @Override
   public GetOperationsResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint() + "?" + Constants.PROJECT_PARAM + project);
-      return client.execute(RequestBuilder.get(url.toString()).build(), this);
+      HttpUriRequest request =
+          RequestBuilder.get(client.createUri(endpoint())).addParameter(PROJECT, project).build();
+      return client.execute(request, this);
     } catch (IOException ioe) {
       String error = String.format(
           "Failed to retrieve the operations for project: '%s' due to: %s",

--- a/src/main/java/com/ontotext/refine/client/command/preferences/GetPreferenceCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/preferences/GetPreferenceCommand.java
@@ -37,7 +37,7 @@ public class GetPreferenceCommand implements RefineCommand<GetPreferenceCommandR
   public GetPreferenceCommandResponse execute(RefineClient client) throws RefineException {
     try {
       HttpUriRequest request = RequestBuilder
-          .get(client.createUrl(endpoint()).toString())
+          .get(client.createUri(endpoint()))
           .addParameter("name", property)
           .build();
 

--- a/src/main/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommand.java
@@ -51,7 +51,7 @@ public class SetPreferenceCommand implements RefineCommand<SetPreferenceCommandR
       form.add(new BasicNameValuePair("value", value.toString()));
 
       HttpUriRequest request = RequestBuilder
-          .post(client.createUrl(endpoint()).toString())
+          .post(client.createUri(endpoint()))
           .addParameter("name", property)
           .setEntity(new UrlEncodedFormEntity(form, StandardCharsets.UTF_8))
           .build();

--- a/src/main/java/com/ontotext/refine/client/command/processes/GetProcessesCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/processes/GetProcessesCommand.java
@@ -11,6 +11,7 @@ import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.HttpParser;
 import com.ontotext.refine.client.util.JsonParser;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collection;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -42,10 +43,10 @@ public class GetProcessesCommand implements RefineCommand<GetProcessesCommandRes
   @Override
   public GetProcessesCommandResponse execute(RefineClient client) throws RefineException {
     try {
-      String url = client.createUrl(endpoint()).toString();
+      URI uri = client.createUri(endpoint());
 
       HttpUriRequest request =
-          RequestBuilder.get(url).addParameter(Constants.PROJECT, project).build();
+          RequestBuilder.get(uri).addParameter(Constants.PROJECT, project).build();
 
       return client.execute(request, this);
     } catch (IOException ioe) {

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfCommand.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
@@ -56,7 +55,7 @@ public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
       String acceptHeader = rdfFormat.getDefaultMIMEType() + ";charset=" + rdfFormat.getCharset();
 
       HttpUriRequest request = RequestBuilder
-          .post(client.createUrl(endpoint() + ":" + project).toString())
+          .post(client.createUri(endpoint() + ":" + project))
           .addHeader(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
           .addHeader(ACCEPT, acceptHeader)
           .setEntity(entity)
@@ -72,8 +71,7 @@ public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
   }
 
   @Override
-  public ExportRdfResponse handleResponse(HttpResponse response)
-      throws ClientProtocolException, IOException {
+  public ExportRdfResponse handleResponse(HttpResponse response) throws IOException {
     HttpParser.HTTP_PARSER.assureStatusCode(response, HttpStatus.SC_OK);
     return new ExportRdfResponse()
         .setProject(project)

--- a/src/main/java/com/ontotext/refine/client/command/reconcile/GuessColumnTypeCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/reconcile/GuessColumnTypeCommand.java
@@ -11,7 +11,6 @@ import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.command.reconcile.GuessColumnTypeCommandResponse.ReconciliationType;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -50,14 +49,12 @@ public class GuessColumnTypeCommand implements RefineCommand<GuessColumnTypeComm
   @Override
   public GuessColumnTypeCommandResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint());
-
       // TODO not good, but this might take a lot of time depending on the service
       RequestConfig config = RequestConfig
           .custom().setSocketTimeout(0).setConnectTimeout(0).setConnectionRequestTimeout(0).build();
 
       HttpUriRequest request = RequestBuilder
-          .post(url.toString())
+          .post(client.createUri(endpoint()))
           .setConfig(config)
           .addParameter(Constants.PROJECT, project)
           .addParameter("columnName", column)

--- a/src/main/java/com/ontotext/refine/client/command/reconcile/ReconcileCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/reconcile/ReconcileCommand.java
@@ -76,9 +76,9 @@ public class ReconcileCommand implements RefineCommand<ReconcileCommandResponse>
       ObjectNode configuration = CONFIG.deepCopy();
 
       HttpUriRequest request = RequestBuilder
-          .post(client.createUrl(endpoint()).toString())
+          .post(client.createUri(endpoint()))
           .addHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE)
-          .addParameter("project", project)
+          .addParameter(Constants.PROJECT, project)
           .addParameter("columnName", column)
           .addParameter("config", configuration.set("type", columnType.asJson()).toString())
           .addParameter("engine", ENGINE.toString())

--- a/src/main/java/com/ontotext/refine/client/command/version/GetVersionCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/version/GetVersionCommand.java
@@ -11,7 +11,6 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
-import java.net.URL;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -38,10 +37,8 @@ public class GetVersionCommand implements RefineCommand<GetVersionResponse> {
   @Override
   public GetVersionResponse execute(RefineClient client) throws RefineException {
     try {
-      URL url = client.createUrl(endpoint());
-
       HttpUriRequest request = RequestBuilder
-          .get(url.toString())
+          .get(client.createUri(endpoint()))
           .setHeader(ACCEPT, APPLICATION_JSON.getMimeType())
           .build();
 

--- a/src/test/java/com/ontotext/refine/client/IntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/IntegrationTest.java
@@ -1,6 +1,6 @@
 package com.ontotext.refine.client;
 
-import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import org.apache.http.HttpHost;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -53,8 +53,8 @@ public abstract class IntegrationTest {
       try {
         HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
         refineClient = RefineClients.create(httpHost.toURI());
-      } catch (MalformedURLException urlExc) {
-        throw new RuntimeException("Failed to create refine client.", urlExc);
+      } catch (URISyntaxException uriExc) {
+        throw new RuntimeException("Failed to create refine client.", uriExc);
       }
     }
 

--- a/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
@@ -5,7 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.ontotext.refine.client.RefineClient;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.entity.BasicHttpEntity;
@@ -39,8 +39,8 @@ public abstract class BaseCommandTest<T, R extends RefineCommand<T>> {
   void setup() {
     MockitoAnnotations.openMocks(this);
 
-    when(client.createUrl(anyString()))
-        .thenAnswer(answer -> new URL(BASE_URI + answer.getArgument(0, String.class)));
+    when(client.createUri(anyString()))
+        .thenAnswer(answer -> new URI(BASE_URI + answer.getArgument(0, String.class)));
   }
 
   /**

--- a/src/test/java/com/ontotext/refine/client/command/ExpressionPreviewCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/ExpressionPreviewCommandTest.java
@@ -11,9 +11,8 @@ import static org.mockito.Mockito.when;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.ResponseCode;
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
@@ -36,10 +35,10 @@ class ExpressionPreviewCommandTest {
   private ExpressionPreviewCommand command;
 
   @BeforeEach
-  void setUp() throws MalformedURLException {
+  void setUp() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(refineClient.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(refineClient.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     command = RefineCommands
         .expressionPreview()
         .token("test-token")
@@ -52,7 +51,7 @@ class ExpressionPreviewCommandTest {
   @Test
   void should_execute() throws IOException {
     command.execute(refineClient);
-    verify(refineClient).createUrl(anyString());
+    verify(refineClient).createUri(anyString());
     verify(refineClient).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/GetProjectMetadataCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/GetProjectMetadataCommandTest.java
@@ -10,8 +10,8 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.ProtocolVersion;
@@ -37,10 +37,10 @@ class GetProjectMetadataCommandTest {
   private HttpResponse response;
 
   @BeforeEach
-  void setup() throws MalformedURLException {
+  void setup() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(client.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(client.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     when(response.getStatusLine())
         .thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK"));
   }

--- a/src/test/java/com/ontotext/refine/client/command/create/CreateProjectCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/create/CreateProjectCommandTest.java
@@ -10,8 +10,8 @@ import com.ontotext.refine.client.UploadFormat;
 import com.ontotext.refine.client.command.RefineCommands;
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -29,10 +29,10 @@ class CreateProjectCommandTest {
   private CreateProjectCommand command;
 
   @BeforeEach
-  void setUp() throws MalformedURLException {
+  void setUp() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(refineClient.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(refineClient.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
 
     command = RefineCommands.createProject().token("test-token").name("JSON Test (Main)")
         .file(new File("src/test/resources/addresses.csv")).format(UploadFormat.SEPARATOR_BASED)
@@ -45,7 +45,7 @@ class CreateProjectCommandTest {
   void should_execute() throws IOException {
     command.execute(refineClient);
 
-    verify(refineClient).createUrl(anyString());
+    verify(refineClient).createUri(anyString());
     verify(refineClient).execute(any(), any());
   }
 }

--- a/src/test/java/com/ontotext/refine/client/command/delete/DeleteProjectCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/delete/DeleteProjectCommandTest.java
@@ -13,9 +13,8 @@ import com.ontotext.refine.client.ResponseCode;
 import com.ontotext.refine.client.command.RefineCommands;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpVersion;
@@ -41,17 +40,17 @@ class DeleteProjectCommandTest {
   private DeleteProjectCommand command;
 
   @BeforeEach
-  void setUp() throws MalformedURLException {
+  void setUp() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(refineClient.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(refineClient.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     command = RefineCommands.deleteProject().token("test-token").project("1234567890").build();
   }
 
   @Test
   void should_execute() throws IOException {
     command.execute(refineClient);
-    verify(refineClient).createUrl(anyString());
+    verify(refineClient).createUri(anyString());
     verify(refineClient).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/export/ExportRowsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/export/ExportRowsCommandTest.java
@@ -11,8 +11,8 @@ import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.ProtocolVersion;
@@ -38,10 +38,10 @@ class ExportRowsCommandTest {
   private HttpResponse response;
 
   @BeforeEach
-  void setup() throws MalformedURLException {
+  void setup() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(client.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(client.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     when(response.getStatusLine())
         .thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK"));
   }

--- a/src/test/java/com/ontotext/refine/client/command/models/GetProjectModelsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/models/GetProjectModelsCommandTest.java
@@ -37,7 +37,7 @@ class GetProjectModelsCommandTest
   void execute_successful() throws IOException {
     assertDoesNotThrow(() -> command().execute(client));
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(any(), any());
   }
 
@@ -47,7 +47,7 @@ class GetProjectModelsCommandTest
 
     assertThrows(RefineException.class, () -> command().execute(client));
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommandTest.java
@@ -15,9 +15,8 @@ import com.ontotext.refine.client.ResponseCode;
 import com.ontotext.refine.client.command.RefineCommands;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpVersion;
@@ -42,9 +41,9 @@ class ApplyOperationsCommandTest {
   private ApplyOperationsCommand command;
 
   @BeforeEach
-  void setUp() throws MalformedURLException {
+  void setUp() throws URISyntaxException {
     refineClient = mock(RefineClient.class);
-    when(refineClient.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(refineClient.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     command = RefineCommands.applyOperations().token("test-token").project("1234567890")
         .operations(from("foo")).build();
   }
@@ -53,7 +52,7 @@ class ApplyOperationsCommandTest {
   void should_execute() throws IOException {
     command.execute(refineClient);
 
-    verify(refineClient).createUrl(anyString());
+    verify(refineClient).createUri(anyString());
     verify(refineClient).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/operations/GetOperationsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/operations/GetOperationsCommandTest.java
@@ -38,7 +38,7 @@ class GetOperationsCommandTest
   void execute_successful() throws IOException {
     assertDoesNotThrow(() -> command().execute(client));
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(any(), any());
   }
 
@@ -53,7 +53,7 @@ class GetOperationsCommandTest
         "Failed to retrieve the operations for project: '" + PROJECT_ID + "' due to: Test error",
         exception.getMessage());
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommandTest.java
@@ -16,7 +16,7 @@ import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
@@ -55,8 +55,8 @@ class SetPreferenceCommandTest {
         .setToken("test-token")
         .build();
 
-    when(client.createUrl(anyString()))
-        .then(answer -> new URL("http://localhost:3333" + answer.getArgument(0)));
+    when(client.createUri(anyString()))
+        .then(answer -> new URI("http://localhost:3333" + answer.getArgument(0)));
   }
 
   @Test

--- a/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
@@ -58,7 +58,7 @@ class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, ExportRdfC
   void execute_successful() throws IOException {
     assertDoesNotThrow(() -> command().execute(client));
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(requestCaptor.capture(), any());
 
     HttpUriRequest request = requestCaptor.getValue();
@@ -78,7 +78,7 @@ class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, ExportRdfC
         "Export of RDF data failed for project: '" + PROJECT_ID + "' due to: Test error",
         exc.getMessage());
 
-    verify(client).createUrl(anyString());
+    verify(client).createUri(anyString());
     verify(client).execute(any(), any());
   }
 

--- a/src/test/java/com/ontotext/refine/client/command/reconcile/ReconServiceRegistrationCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/reconcile/ReconServiceRegistrationCommandTest.java
@@ -18,7 +18,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
@@ -64,8 +64,8 @@ class ReconServiceRegistrationCommandTest {
         .setToken("test-token")
         .build();
 
-    when(client.createUrl(anyString()))
-        .then(answer -> new URL(OR_BASE_URI + answer.getArgument(0)));
+    when(client.createUri(anyString()))
+        .then(answer -> new URI(OR_BASE_URI + answer.getArgument(0)));
   }
 
   @Test

--- a/src/test/java/com/ontotext/refine/client/command/version/GetVersionCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/version/GetVersionCommandTest.java
@@ -15,9 +15,8 @@ import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -44,17 +43,17 @@ class GetVersionCommandTest {
   private GetVersionCommand command;
 
   @BeforeEach
-  void setUp() throws MalformedURLException {
+  void setUp() throws URISyntaxException {
     MockitoAnnotations.openMocks(this);
 
-    when(refineClient.createUrl(anyString())).thenReturn(new URL("http://localhost:3333/"));
+    when(refineClient.createUri(anyString())).thenReturn(new URI("http://localhost:3333/"));
     command = RefineCommands.getVersion().build();
   }
 
   @Test
   void should_execute() throws IOException {
     command.execute(refineClient);
-    verify(refineClient).createUrl(anyString());
+    verify(refineClient).createUri(anyString());
     verify(refineClient).execute(any(), any());
   }
 


### PR DESCRIPTION
- Changed the object for the creation of the full address of the command
endpoints from `URL` to `URI`.
- Updated all of the affected command implementations and tests.
- Prepare for release of version `1.3.0`.