### PR TITLE
Introduces few enhancements, couple of bug fixes and changes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ implemented in similar standard, which makes the usage of the library intuitive 
 </p>
 
 
-From the above diagram is represented the basic architecture of the library. The components represented with the blue
+On the above diagram is represented the basic architecture of the library. The components represented with the blue
 cuboids are the different services, applications or APIs, which can use the library in order to complete specific
 functionality. The green one is represents the library itself, which hava a connection to the OntoRefine tool integrated
 within GraphDB.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,10 +12,12 @@ over the Google's `OpenRefine`.
 
 <details>
   <summary>tl;dr</summary>
-  OntoRefine is based on the open source [OpenRefine](https://openrefine.org/) data transformation tool, supported and
-  maintained by Google. It extends the standard functionalities of the `OpenRefine` by adding quick mapping of the data
-  to RDF format, which can be directly stored in GraphDB. OntoRefine user interface is integrated in the GraphDB
-  Workbench from where the user can process the different dataset and import the data to the database.
+  <i>
+    OntoRefine is based on the open source <a href="https://openrefine.org/">OpenRefine</a> data transformation tool,
+    supported and maintained by Google. It extends the standard functionalities of the `OpenRefine` by adding quick
+    mapping of the data to RDF format, which can be directly stored in GraphDB. OntoRefine user interface is integrated
+    in the GraphDB Workbench from where the user can process the different dataset and import the data to the database.
+  </i>
 </details>
 
 The client library communicates with OntoRefine through HTTP requests, where every command represents call to different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@
 
 ### New
 
+ - Enhanced the `RefineClients` to allow creation of different types of `RefineClient` instances. Now it can produce security aware client, which accepts credentials
+   provider allowing to execute commands over secured Refine tools. Additionally there is an option, which allows full customization over the internal HTTP client that
+   will be used by the `RefineClient` instance.
 
 ### Changes
 
+ - Deprecated `RefineClients#create` method in favor of `RefineClients#standard`. Now that there are more methods in `RefineClients`, `create` doesn't seems
+   appropriate as it doesn't provide context for the type of the produced client.
 
 ### Bug fixes
+
+ - Fixed the method `setOptions` in `ExportRowsCommand#Builder` to follow the fluent pattern.
+ - Reverted the wrongly committed changes to the interface implementation of the `RefineClient`.
 
 
 ## Version 1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
  - Fixed the method `setOptions` in `ExportRowsCommand#Builder` to follow the fluent pattern.
  - Reverted the wrongly committed changes to the interface implementation of the `RefineClient`.
+ - Fixed an issue with the `ExportRdfCommand` request entity. If the initial request fails, it is retried due to the retry policy of the client. However the entity
+   contains stream, which has been closed, which causes the retry to also fail without obvious reason. The simplest fix was to wrap the `BasicHttpEntity` in
+   `BufferedHttpEntity`, which is always repeatable.
 
 
 ## Version 1.3

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ complete given operation.
  <dependency>
      <groupId>com.ontotext</groupId>
      <artifactId>ontorefine-client</artifactId>
-     <version>1.3.0</version>
+     <version>1.4.0</version>
  </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An OntoRefine Client Library</description>

--- a/src/main/java/com/ontotext/refine/client/RefineClient.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClient.java
@@ -1,5 +1,6 @@
 package com.ontotext.refine.client;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -8,12 +9,11 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 
-
 /**
  * Represents the client which purpose is to provide the HTTP communication between the application
  * and the Refine instance.
  */
-public class RefineClient implements AutoCloseable {
+public class RefineClient implements Closeable {
 
   private final URI uri;
   private final CloseableHttpClient httpClient;
@@ -58,7 +58,7 @@ public class RefineClient implements AutoCloseable {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws IOException {
     httpClient.close();
   }
 

--- a/src/main/java/com/ontotext/refine/client/RefineClients.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClients.java
@@ -2,12 +2,77 @@ package com.ontotext.refine.client;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
+/**
+ * Defines different instances of {@link RefineClient}.
+ *
+ * @author Antoniy Kunchev
+ */
+// TODO configure some sensible timeouts and other configurations
 public interface RefineClients {
 
+  /**
+   * Creates default {@link RefineClient} instance.
+   *
+   * @deprecated use {@link #standard(String)} instead
+   * @param uri to be used as base for the commands execution. Basically the address of the Refine
+   *        tool instance
+   * @return new default {@link RefineClient} instance
+   * @throws URISyntaxException when the input <code>uri</code> argument is invalid
+   */
+  @Deprecated
   static RefineClient create(String uri) throws URISyntaxException {
-    // TODO configure some sensible timeouts and other configurations
+    return standard(uri);
+  }
+
+  /**
+   * Creates default {@link RefineClient} instance.
+   *
+   * @param uri to be used as base for the commands execution. Basically the address of the Refine
+   *        tool instance
+   * @return new default {@link RefineClient} instance
+   * @throws URISyntaxException when the input <code>uri</code> argument is invalid
+   */
+  static RefineClient standard(String uri) throws URISyntaxException {
     return new RefineClient(new URI(uri), HttpClients.createDefault());
+  }
+
+  /**
+   * Creates secured {@link RefineClient} instance. It uses the given {@link CredentialsProvider}
+   * for authentication, when the commands are executed.
+   *
+   * @param uri to be used as base for the commands execution. Basically the address of the Refine
+   *        tool instance
+   * @param credsProvider for the credentials that must be used when the commands are executed
+   * @return new {@link RefineClient} instance
+   * @throws URISyntaxException when the input <code>uri</code> argument is invalid
+   * @throws NullPointerException if the <code>credsProvider</code> argument is <code>null</code>
+   */
+  static RefineClient securityAware(String uri, CredentialsProvider credsProvider)
+      throws URISyntaxException {
+    Validate.notNull(credsProvider, "The credential provider is required.");
+    HttpClientBuilder client = HttpClients.custom().setDefaultCredentialsProvider(credsProvider);
+    return new RefineClient(new URI(uri), client.build());
+  }
+
+  /**
+   * Creates {@link RefineClient} instance using the provided {@link CloseableHttpClient}. This
+   * allows more freedom, when configuring the behavior of the client.
+   *
+   * @param uri to be used as base for the commands execution. Basically the address of the Refine
+   *        tool instance
+   * @param internalClient to be used for execution of the requests to the Refine tool
+   * @return new {@link RefineClient} instance
+   * @throws URISyntaxException when the input <code>uri</code> argument is invalid
+   */
+  static RefineClient custom(String uri, CloseableHttpClient internalClient)
+      throws URISyntaxException {
+    Validate.notNull(internalClient, "The internal client argument is required.");
+    return new RefineClient(new URI(uri), internalClient);
   }
 }

--- a/src/main/java/com/ontotext/refine/client/RefineClients.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClients.java
@@ -55,7 +55,7 @@ public interface RefineClients {
    */
   static RefineClient securityAware(String uri, CredentialsProvider credsProvider)
       throws URISyntaxException {
-    Validate.notNull(credsProvider, "The credential provider is required.");
+    Validate.notNull(credsProvider, "The credentials provider is required.");
     HttpClientBuilder client = HttpClients.custom().setDefaultCredentialsProvider(credsProvider);
     return new RefineClient(new URI(uri), client.build());
   }

--- a/src/main/java/com/ontotext/refine/client/command/export/ExportRowsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/export/ExportRowsCommand.java
@@ -138,8 +138,9 @@ public class ExportRowsCommand implements RefineCommand<ExportRowsResponse> {
       return this;
     }
 
-    public void setOptions(Options options) {
+    public Builder setOptions(Options options) {
       this.options = options;
+      return this;
     }
 
     public Builder setToken(String token) {

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfCommand.java
@@ -18,6 +18,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 
@@ -58,7 +59,7 @@ public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
           .post(client.createUri(endpoint() + ":" + project))
           .addHeader(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
           .addHeader(ACCEPT, acceptHeader)
-          .setEntity(entity)
+          .setEntity(new BufferedHttpEntity(entity))
           .build();
 
       return client.execute(request, this);

--- a/src/test/java/com/ontotext/refine/client/IntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/IntegrationTest.java
@@ -52,7 +52,7 @@ public abstract class IntegrationTest {
     if (refineClient == null) {
       try {
         HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
-        refineClient = RefineClients.create(httpHost.toURI());
+        refineClient = RefineClients.standard(httpHost.toURI());
       } catch (URISyntaxException uriExc) {
         throw new RuntimeException("Failed to create refine client.", uriExc);
       }

--- a/src/test/java/com/ontotext/refine/client/ReconciliationIntegrationTests.java
+++ b/src/test/java/com/ontotext/refine/client/ReconciliationIntegrationTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
  */
 class ReconciliationIntegrationTests extends CommandIntegrationTest {
 
-  private static final String RECON_SERVICE = "https://data.biblissima.fr/api/reconcile";
+  private static final String RECON_SERVICE = "https://reconcile.ontotext.com/organizations";
   private static final String RESTAURANTS_CSV = "integration/reduced_netherlands_restaurants.csv";
 
   /**

--- a/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
+++ b/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
@@ -1,0 +1,52 @@
+package com.ontotext.refine.client;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URISyntaxException;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Simple test for {@link RefineClients}.
+ *
+ * @author Antoniy Kunchev
+ */
+class RefineClientsTest {
+
+  private static final String URI = "http://ontorefine.com/orefine";
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void create_successful() throws URISyntaxException {
+    assertNotNull(assertDoesNotThrow(() -> RefineClients.create(URI)));
+  }
+
+  @Test
+  void securityAware_exceptionOnMissingCredsProvider() throws URISyntaxException {
+    assertThrows(NullPointerException.class, () -> RefineClients.securityAware(URI, null));
+  }
+
+  @Test
+  void securityAware_successful() throws URISyntaxException {
+    RefineClient client =
+        assertDoesNotThrow(() -> RefineClients.securityAware(URI, new BasicCredentialsProvider()));
+
+    assertNotNull(client);
+  }
+
+  @Test
+  void custom_exceptionOnMissingClientArg() {
+    assertThrows(NullPointerException.class, () -> RefineClients.custom(URI, null));
+  }
+
+  @Test
+  void custom_successful() {
+    RefineClient client =
+        assertDoesNotThrow(() -> RefineClients.custom(URI, HttpClients.custom().build()));
+
+    assertNotNull(client);
+  }
+}


### PR DESCRIPTION

- Enhanced the `RefineClients` type with additional methods, which are
producing different types of `RefineClient` instances. The intention
behind this change is to allow the developers to define their own way of
securing the client or pre-configure different aspects of it, like
timeouts, connections, etc.
- Fix `setOptions` method in `ExportRowsCommand#Builder` to follow the
fluent pattern.
- Reverted the wrongly committed changes to the `RefineCleint` type.
- Fixed broken integration tests for reconciliation registration due to
changes in the response from the reconciliation address. We are now
going to use our own services for this test as they are public and
usable.
- Fixed issue with following retry of the export RDF request, if the
initial one fails. The problem was that the request entity contains
stream of data, which is consumed on the first request and rereading it
causes error. The fix was to wrap the `BasicHttpEntity` in
`BufferedHttpEntity`.
- Added minor and cosmetic fixes to the library documentation.
- Removed the `SNAPSHOT` part of the library version.