### PR TITLE
Introduces additional mechanism for RDF data export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,22 @@
 
 ### New
 
+ - Introduced new command for RDF data export. Instead of a mapping, the command takes advantage SPARQL API of the GraphDB and executed CONSTRUCT query. The query itself
+   contains the data source that should be transformed, in this case that is a OntoRefine project.
+   In order to make the functionality reusable, in other words executable for multiple projects, the query which is passed to the command contains placeholder for the
+   refine project. This allows multiple execution of the defined query over projects with similar data structure.
+   The command has one limitation that comes from the GraphDB itself, it requires existence of a repository in order to use the SPARQL API, no matter that it uses refine
+   project as data source.
+ - Introduces a way to execute integration tests over secured GraphDB. The functionality is implemented in the `IntegrationTest` class, which spawns the GraphDB instance
+   used for the tests. The mechanism allow so enable/disable the security on the fly by creating an refine client instance, which uses credentials and another that doesn't. 
 
 ### Changes
 
+ - Updated the GraphDB version for the integration tests to 10.0.0-M1 in order to take advantage of the new strategy for the product, which does not require licensing for
+   the core functionalities of the product.
+ - Added repository via configuration file provisioning to the docker environment, for the integration tests. The name of the repository is `integration-tests` and it is
+   created, when the GraphDB is initialized.
+ - Renamed the `ExportRdfCommand` to `DefaultExportRdfCommand`. This is a breaking change for implementations that refer to the concrete command class.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Bug fixes
 
+ - Added logic which allow usage of the RDF mapping JSON in different format in the export RDF and apply operations commands. It fixes usability issue related to the
+   extraction of the RDF mapping from different places in the user interface in the OntoRefine or Mapping UI.
+
 
 ## Version 1.4
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ complete given operation.
  <dependency>
      <groupId>com.ontotext</groupId>
      <artifactId>ontorefine-client</artifactId>
-     <version>1.4.0</version>
+     <version>1.5.0</version>
  </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The operations that are currently supported:
 - Project deletion - deletes existing project in OntoRefine
 - Project data export - exports the data of a OntoRefine project
 - Exporting project data in RDF format - exports the data of a OntoRefine project in RDF format using the RDF mapping defined with the Mapping UI tool
+- Exporting project data in RDF format via SPARQL - exports the data of a OntoRefine project in RDF format using a SPARQL CONSTRUCT query
 - Applying of operations over project data - applies set of operation to OntoRefine project. The operations are represented via JSON configuration
 - Project operations exporting - exports the operations that are applied to OntoRefine project. The result is in JSON format and can be directly used in different project
 - Version retrieval - provides information about the version of the OntoRefine tool

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>1.5.0</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An OntoRefine Client Library</description>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <junit.jupiter.version>5.8.1</junit.jupiter.version>
         <mockito.version>3.8.0</mockito.version>
         <testcontainers.version>1.16.0</testcontainers.version>
-        <e2e.graphdb.docker.image>ontotext/graphdb:9.10.0-ee</e2e.graphdb.docker.image>
+        <e2e.graphdb.docker.image>ontotext/graphdb:10.0.0-M1</e2e.graphdb.docker.image>
 
         <checkstyle.enabled>true</checkstyle.enabled>
     </properties>
@@ -164,6 +164,13 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-rio-turtle</artifactId>
+            <version>${rdf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
@@ -10,7 +10,8 @@ import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.command.preferences.GetPreferenceCommand;
 import com.ontotext.refine.client.command.preferences.SetPreferenceCommand;
 import com.ontotext.refine.client.command.processes.GetProcessesCommand;
-import com.ontotext.refine.client.command.rdf.ExportRdfCommand;
+import com.ontotext.refine.client.command.rdf.DefaultExportRdfCommand;
+import com.ontotext.refine.client.command.rdf.SparqlBasedExportRdfCommand;
 import com.ontotext.refine.client.command.reconcile.GuessColumnTypeCommand;
 import com.ontotext.refine.client.command.reconcile.ReconServiceRegistrationCommand;
 import com.ontotext.refine.client.command.reconcile.ReconcileCommand;
@@ -103,12 +104,21 @@ public interface RefineCommands {
   }
 
   /**
-   * Provides a builder instance for the {@link ExportRdfCommand}.
+   * Provides a builder instance for the {@link DefaultExportRdfCommand}.
    *
    * @return new builder instance
    */
-  static ExportRdfCommand.Builder exportRdf() {
-    return new ExportRdfCommand.Builder();
+  static DefaultExportRdfCommand.Builder exportRdf() {
+    return new DefaultExportRdfCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link SparqlBasedExportRdfCommand}.
+   *
+   * @return new builder instance
+   */
+  static SparqlBasedExportRdfCommand.Builder exportRdfUsingSparql() {
+    return new SparqlBasedExportRdfCommand.Builder();
   }
 
   /**

--- a/src/main/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/operations/ApplyOperationsCommand.java
@@ -17,6 +17,7 @@ import com.ontotext.refine.client.Operation;
 import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
+import com.ontotext.refine.client.util.mappings.MappingsNormalizer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +67,11 @@ public class ApplyOperationsCommand implements RefineCommand<ApplyOperationsResp
       form.add(new BasicNameValuePair(Constants.PROJECT, projectId));
 
       String ops =
-          Arrays.stream(operations).map(Operation::asJson).collect(Collectors.joining(","));
+          Arrays.stream(operations)
+              .map(Operation::asJson)
+              .map(MappingsNormalizer::forApplyOperations)
+              .collect(Collectors.joining(","));
+
       String opsAsJsonArray = appendIfMissing(prependIfMissing(ops, "["), "]");
       form.add(new BasicNameValuePair("operations", opsAsJsonArray));
 

--- a/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
@@ -11,6 +11,7 @@ import com.ontotext.refine.client.RefineClient;
 import com.ontotext.refine.client.command.RefineCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.HttpParser;
+import com.ontotext.refine.client.util.mappings.MappingsNormalizer;
 import java.io.IOException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
@@ -50,7 +51,7 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
       BasicHttpEntity entity = new BasicHttpEntity();
       entity.setContentType(APPLICATION_JSON.getMimeType());
       entity.setContentEncoding(APPLICATION_JSON.getCharset().toString());
-      entity.setContent(IOUtils.toInputStream(mapping, UTF_8));
+      entity.setContent(IOUtils.toInputStream(MappingsNormalizer.forRdfExport(mapping), UTF_8));
 
       RDFFormat rdfFormat = format.getRdfFormat();
       String acceptHeader = rdfFormat.getDefaultMIMEType() + ";charset=" + rdfFormat.getCharset();

--- a/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
@@ -21,19 +21,19 @@ import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.BufferedHttpEntity;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
-
 /**
- * A command that exports the data of specific project in RDF format.
+ * A command that exports the data of specific project in RDF format using the mapping defined in
+ * the Mapping UI.
  *
  * @author Antoniy Kunchev
  */
-public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
+public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse> {
 
   private final String project;
   private final String mapping;
   private final ResultFormat format;
 
-  private ExportRdfCommand(String project, String mapping, ResultFormat format) {
+  private DefaultExportRdfCommand(String project, String mapping, ResultFormat format) {
     this.project = project;
     this.mapping = mapping;
     this.format = format;
@@ -80,7 +80,7 @@ public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
   }
 
   /**
-   * Builder for {@link ExportRdfCommand}.
+   * Builder for {@link DefaultExportRdfCommand}.
    *
    * @author Antoniy Kunchev
    */
@@ -106,15 +106,15 @@ public class ExportRdfCommand implements RefineCommand<ExportRdfResponse> {
     }
 
     /**
-     * Builds a {@link ExportRdfCommand}.
+     * Builds a {@link DefaultExportRdfCommand}.
      *
      * @return a command
      */
-    public ExportRdfCommand build() {
+    public DefaultExportRdfCommand build() {
       notBlank(project, "Missing 'project' argument");
       notBlank(mapping, "Missing 'mapping' argument");
       notNull(format, "Missing 'format' argument");
-      return new ExportRdfCommand(project, mapping, format);
+      return new DefaultExportRdfCommand(project, mapping, format);
     }
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
@@ -2,7 +2,7 @@ package com.ontotext.refine.client.command.rdf;
 
 
 /**
- * Holds the result from {@link ExportRdfCommand}.
+ * Holds the result from export RDF commands.
  *
  * @author Antoniy Kunchev
  */

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
@@ -3,8 +3,8 @@ package com.ontotext.refine.client.command.rdf;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
- * Contains values for the result format of the {@link ExportRdfCommand}. Basically it is a proxy
- * for the {@link RDFFormat} values, which decouples the 'RDF4J' dependency from the client.
+ * Contains values for the result format of the export RDF commands. Basically it is a proxy for the
+ * {@link RDFFormat} values, which decouples the 'RDF4J' dependency from the client.
  *
  * @author Antoniy Kunchev
  */

--- a/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedExportRdfCommand.java
@@ -1,0 +1,173 @@
+package com.ontotext.refine.client.command.rdf;
+
+import static com.ontotext.refine.client.util.HttpParser.HTTP_PARSER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.Validate.notBlank;
+import static org.apache.commons.lang3.Validate.notNull;
+import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.entity.ContentType.APPLICATION_FORM_URLENCODED;
+
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.eclipse.rdf4j.rio.RDFFormat;
+
+/**
+ * A command that exports the data of specific project in RDF format using a SPARQL Construct query.
+ * The query should be template containing specific placeholder for the project identifier. The
+ * placeholder allows execution of the same query over multiple projects with same data
+ * structure.<br>
+ * The default placeholder set in the command is <code>#project_placeholder#</code>, but it can be
+ * changed by providing different one, when building the command.
+ *
+ * @author Antoniy Kunchev
+ */
+public class SparqlBasedExportRdfCommand implements RefineCommand<ExportRdfResponse> {
+
+  private final String project;
+  private final String projectPlaceholder;
+  private final String query;
+  private final ResultFormat format;
+  private final String repository;
+
+  private SparqlBasedExportRdfCommand(
+      String project,
+      String projectPlaceholder,
+      String query,
+      ResultFormat format,
+      String repository) {
+    this.project = project;
+    this.projectPlaceholder = projectPlaceholder;
+    this.query = query;
+    this.format = format;
+    this.repository = repository;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/repositories/{repo}";
+  }
+
+  @Override
+  public ExportRdfResponse execute(RefineClient client) throws RefineException {
+    try {
+      RDFFormat rdfFormat = format.getRdfFormat();
+      String acceptHeader = rdfFormat.getDefaultMIMEType() + ";charset=" + rdfFormat.getCharset();
+
+      HttpUriRequest request = RequestBuilder
+          .post(client.createUri(endpoint().replace("{repo}", repository)))
+          .addHeader(ACCEPT, acceptHeader)
+          .addHeader(CONTENT_TYPE, APPLICATION_FORM_URLENCODED.withCharset(UTF_8).toString())
+          .setEntity(buildEntity())
+          .build();
+
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      throw new RefineException(
+          "Export of RDF data failed for project: '%s' due to: %s",
+          project,
+          ioe.getMessage());
+    }
+  }
+
+  /**
+   * Builds the request entity with the expected content. The produced {@link HttpEntity} is
+   * repeatable so that it can be retried.
+   */
+  private HttpEntity buildEntity() throws IOException {
+    BasicHttpEntity entity = new BasicHttpEntity();
+    entity.setContent(IOUtils.toInputStream(buildRequestContent(), UTF_8));
+    return new BufferedHttpEntity(entity);
+  }
+
+  /**
+   * Replaces the placeholder for the project in the query template.<br>
+   * Effectively:
+   *
+   * <pre>
+   * SERVICE &lt;rdf-mapper:ontorefine:#project_placeholder#&gt;
+   *
+   * is transformed into
+   *
+   * SERVICE &lt;rdf-mapper:ontorefine:1958197932150&gt;
+   * </pre>
+   * And prepends the expected field for the request.
+   */
+  private String buildRequestContent() {
+    String fixedQuery = query.replaceFirst(projectPlaceholder, project);
+    return StringUtils.prependIfMissing(fixedQuery, "query=");
+  }
+
+  @Override
+  public ExportRdfResponse handleResponse(HttpResponse response) throws IOException {
+    HTTP_PARSER.assureStatusCode(response, SC_OK);
+    return new ExportRdfResponse()
+        .setProject(project)
+        .setResult(IOUtils.toString(response.getEntity().getContent(), UTF_8));
+  }
+
+  /**
+   * Builder for {@link SparqlBasedExportRdfCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String project;
+    private String projectPlaceholder = "#project_placeholder#";
+    private String query;
+    private ResultFormat format;
+    private String repository;
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setProjectPlaceholder(String projectPlaceholder) {
+      this.projectPlaceholder = projectPlaceholder;
+      return this;
+    }
+
+    public Builder setQuery(String query) {
+      this.query = query;
+      return this;
+    }
+
+    public Builder setFormat(ResultFormat format) {
+      this.format = format;
+      return this;
+    }
+
+    public Builder setRepository(String repository) {
+      this.repository = repository;
+      return this;
+    }
+
+    /**
+     * Builds a {@link SparqlBasedExportRdfCommand}.
+     *
+     * @return a command
+     */
+    public SparqlBasedExportRdfCommand build() {
+      notBlank(project, "Missing 'project' argument");
+      notBlank(projectPlaceholder, "The 'projectPlaceholder' argument should not be blank");
+      notBlank(query, "Missing 'query' argument");
+      notNull(format, "Missing 'format' argument");
+      notBlank(repository, "Missing 'repository' argument");
+      return new SparqlBasedExportRdfCommand(
+          project, projectPlaceholder, query, format, repository);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/util/mappings/MappingsNormalizer.java
+++ b/src/main/java/com/ontotext/refine/client/util/mappings/MappingsNormalizer.java
@@ -1,0 +1,120 @@
+package com.ontotext.refine.client.util.mappings;
+
+import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.ontotext.refine.client.command.models.GetProjectModelsCommand;
+import com.ontotext.refine.client.command.operations.ApplyOperationsCommand;
+import com.ontotext.refine.client.command.operations.GetOperationsCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import com.ontotext.refine.client.util.mappings.MappingsStructures.MappingJson;
+import com.ontotext.refine.client.util.mappings.MappingsStructures.OperationsJson;
+import java.util.List;
+import java.util.function.Predicate;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Contains convenient logic for normalization of the mappings used for RDF export.
+ *
+ * @author Antoniy Kunchev
+ */
+public class MappingsNormalizer {
+
+  private static final Predicate<JsonNode> NOT_MAPPING_ASSIGNABLE =
+      json -> !JSON_PARSER.isAssignable(json.toString(), MappingJson.class);
+
+  private MappingsNormalizer() {
+    // utility
+  }
+
+  /**
+   * Extracts the RDF mapping JSON from the input JSON. The input can be:<br>
+   * <ul>
+   * <li>operations JSON (retrieved from the OR history UI or extracted via
+   * {@link GetOperationsCommand})
+   * <li>models JSON (extract via {@link GetProjectModelsCommand})
+   * </ul>
+   * If the input is already mapping JSON, it is returned as is.
+   *
+   * @param json to normalize
+   * @return mapping for RDF export or <code>null</code> if the provided JSON cannot be handled
+   */
+  public static String forRdfExport(String json) {
+    if (JSON_PARSER.isAssignable(json, MappingJson.class)) {
+      return json;
+    }
+
+    // operations JSON case
+    if (JSON_PARSER.isAssignable(json, OperationsJson.class)) {
+      return extractMappingsFromOperations(json);
+    }
+
+    // project models case
+    String mappingsStr = tryExtractFromModels(json);
+    if (mappingsStr != null) {
+      return mappingsStr;
+    }
+
+    return null;
+  }
+
+  // extracts the last object for the RDF mapping as there could be more than one saved
+  private static String extractMappingsFromOperations(String json) {
+    try {
+      List<JsonNode> listOfMappings = JSON_PARSER.parseJson(json).findValues("mapping");
+      listOfMappings.removeIf(NOT_MAPPING_ASSIGNABLE);
+      JsonNode lastMapping = listOfMappings.get(listOfMappings.size() - 1);
+      return lastMapping.toString();
+    } catch (RefineException re) { // NOSONAR
+      return null; // shouldn't be reachable
+    }
+  }
+
+  private static String tryExtractFromModels(String json) {
+    if (StringUtils.isBlank(json)) {
+      return null;
+    }
+
+    try {
+      JsonNode models = JSON_PARSER.parseJson(json);
+      JsonNode overlayModels = models.findValue("overlayModels");
+      if (overlayModels == null) {
+        return null;
+      }
+
+      JsonNode mappingDef = overlayModels.findValue("mappingDefinition");
+      if (mappingDef == null) {
+        return null;
+      }
+
+      JsonNode mappings = mappingDef.findValue("mappingDefinition");
+      return mappings != null ? mappings.toString() : null;
+    } catch (RefineException re) { // NOSONAR
+      return null;
+    }
+  }
+
+  /**
+   * Checks, whether the input JSON is mapping for RDF export and if it is, wraps it as operation so
+   * that it can be passed to the {@link ApplyOperationsCommand}.<br>
+   * Otherwise the input argument is returned as is.
+   *
+   * @param json to try to convert to mapping operation
+   * @return mappings wrapped as operation or the input argument
+   */
+  public static String forApplyOperations(String json) {
+    if (!JSON_PARSER.isAssignable(json, MappingJson.class)) {
+      return json;
+    }
+
+    try {
+      return JsonNodeFactory.instance.objectNode()
+          .put("op", "mapping-editor/save-rdf-mapping")
+          .set("mapping", JSON_PARSER.parseJson(json))
+          .toString();
+    } catch (RefineException re) { // NOSONAR
+      return null; // shouldn't be reachable
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/util/mappings/MappingsStructures.java
+++ b/src/main/java/com/ontotext/refine/client/util/mappings/MappingsStructures.java
@@ -1,0 +1,61 @@
+package com.ontotext.refine.client.util.mappings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Contains class representations of the JSON object structures for the mapping JSON used for RDF
+ * export.
+ *
+ * @author Antoniy Kunchev
+ */
+final class MappingsStructures {
+
+  private MappingsStructures() {
+    // utility
+  }
+
+  /**
+   * Structure for materializing the mapping JSON and detect if it can be used directly or it needs
+   * to be normalized.
+   *
+   * @author Antoniy Kunchev
+   */
+  static class MappingJson {
+
+    @JsonProperty("baseIRI")
+    private String baseIri;
+
+    @JsonProperty
+    private Map<String, String> namespaces;
+
+    @JsonProperty
+    private List<Object> subjectMappings;
+  }
+
+  /**
+   * Structure for materializing the single operation from operations JSON.
+   *
+   * @author Antoniy Kunchev
+   */
+  static class OperationEntry {
+
+    @JsonProperty
+    private String description;
+
+    @JsonProperty
+    private Object operation;
+  }
+
+  /**
+   * Structure for materializing the operations JSON.
+   *
+   * @author Antoniy Kunchev
+   */
+  static class OperationsJson {
+
+    @JsonProperty
+    private List<OperationEntry> entries;
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/CommandIntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/CommandIntegrationTest.java
@@ -23,6 +23,12 @@ public abstract class CommandIntegrationTest extends IntegrationTest {
 
   private static final long WAIT_FOR_PROCESSES = 20;
 
+  // For transparency reason
+  @Override
+  protected void security(Turn turn) {
+    super.security(turn);
+  }
+
   /**
    * Provides CSRF tokens, retrieved from OntoRefine tool.
    *

--- a/src/test/java/com/ontotext/refine/client/ExportIntegrationTests.java
+++ b/src/test/java/com/ontotext/refine/client/ExportIntegrationTests.java
@@ -1,5 +1,6 @@
 package com.ontotext.refine.client;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,12 +14,16 @@ import com.ontotext.refine.client.command.operations.ApplyOperationsResponse;
 import com.ontotext.refine.client.command.rdf.ExportRdfResponse;
 import com.ontotext.refine.client.command.rdf.ResultFormat;
 import com.ontotext.refine.client.exceptions.RefineException;
+import com.ontotext.refine.client.util.RdfTestUtils;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,7 +41,7 @@ class ExportIntegrationTests extends CommandIntegrationTest {
   private static final String RESTAURANTS_CSV = "integration/reduced_netherlands_restaurants.csv";
 
   /**
-   * Note the scenario uses reduced dataset in order to complete the operations over it quickly!
+   * Note the scenario uses reduced dataset in order to complete the operations quickly!
    *
    * <p>Scenario 1:<br>
    * <br>
@@ -97,7 +102,7 @@ class ExportIntegrationTests extends CommandIntegrationTest {
   }
 
   /**
-   * Note the scenario uses reduced dataset in order to complete the operations over it quickly!
+   * Note the scenario uses reduced dataset in order to complete the operations quickly!
    *
    * <p>Scenario 2:<br>
    * <br>
@@ -122,12 +127,16 @@ class ExportIntegrationTests extends CommandIntegrationTest {
 
     ExportRdfResponse exportRdfResponse = exportAsRdf(projectId);
 
-    String expected = IOUtils.resourceToString(
-        "/integration/expected/scenario_2_reduced_netherlands_restaurants_exportRdf.ttl",
-        StandardCharsets.UTF_8);
+    InputStream expected = getClass().getResourceAsStream(
+        "/integration/expected/scenario_2_reduced_netherlands_restaurants_exportRdf.ttl");
+    
+    boolean areEqual =
+        RdfTestUtils.compareAsRdf(
+            expected,
+            new ByteArrayInputStream(exportRdfResponse.getResult().getBytes()),
+            RDFFormat.TURTLE);
 
-    // the files cannot be compared directly because of the IRI generation
-    assertEquals(expected.length(), exportRdfResponse.getResult().length());
+    assertTrue("The expected result different then the acual one.", areEqual);
 
     DeleteProjectResponse deleteResponse = deleteProject(projectId);
     assertEquals(ResponseCode.OK, deleteResponse.getCode());

--- a/src/test/java/com/ontotext/refine/client/IntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/IntegrationTest.java
@@ -1,32 +1,52 @@
 package com.ontotext.refine.client;
 
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.junit.AfterClass;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 /**
- * Base class for all integration tests which are going to execute operations against existing
- * OntoRefine instance.<br>
+ * Base class for all integration tests which execute operations against existing OntoRefine
+ * instance.<br>
  * The class contains logic for spawning GraphDB with OntoRefine instance using Docker image with
  * specific version. The container will be reused by all concrete implementations, which should not
  * be coupled by any projects or resources created by other test/s in order to keep the environment
- * clean.
+ * clean.<br>
+ * Additionally there is a option to enable/disable the security of the GDB instance.
  *
  * @author Antoniy Kunchev
  */
 @Testcontainers
 public abstract class IntegrationTest {
 
-  private static final String DEFAUL_GDB_DOCKER_IMAGE = "ontotext/graphdb:9.10.0-ee";
+  private static final String DEFAUL_GDB_DOCKER_IMAGE = "ontotext/graphdb:10.0.0-M1";
 
   // Tries to retrieve the image name from the surefire plugin property. Otherwise uses the default
   private static final DockerImageName GDB_DOCKER_IMAGE_NAME =
       DockerImageName.parse(System.getProperty("graphdb.docker.image", DEFAUL_GDB_DOCKER_IMAGE));
 
   private static final int PORT = 7200;
+
+  protected static final String REPO_NAME = "integration-tests";
 
   protected static final GenericContainer<?> GDB_DOCKER;
 
@@ -36,12 +56,63 @@ public abstract class IntegrationTest {
     GDB_DOCKER = new GenericContainer<>(GDB_DOCKER_IMAGE_NAME)
         .withExposedPorts(PORT)
         .withLogConsumer(frame -> System.out.print(frame.getUtf8String()))
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("/integration/config.ttl"),
+            "/opt/graphdb/home/data/repositories/" + REPO_NAME + "/config.ttl")
         .waitingFor(Wait.forLogMessage(".*Started GraphDB in workbench mode at port 7200.*", 1));
 
     GDB_DOCKER.start();
   }
 
   private RefineClient refineClient;
+  private RefineClient securedRefineClient;
+
+  private static boolean isSecurityEnabled;
+
+  @AfterClass
+  private static void afterAll() {
+    isSecurityEnabled = false;
+  }
+
+  /**
+   * Enables/disables the security of the GraphDB and the {@link RefineClient} instance that will be
+   * used in the tests.
+   *
+   * @param turn controls the switching
+   */
+  protected void security(Turn turn) {
+    isSecurityEnabled = Turn.ON.equals(turn);
+    if (isSecurityEnabled && securedRefineClient == null) {
+      initSecurity();
+    }
+  }
+
+  /**
+   * Enables or disables the security of GpraphDB instance.<br>
+   * The functionality is achieved using the REST service of GDB.
+   */
+  private void initSecurity() {
+    try {
+      BasicHttpEntity entity = new BasicHttpEntity();
+      entity.setContent(
+          IOUtils.toInputStream(Boolean.toString(isSecurityEnabled), StandardCharsets.UTF_8));
+      HttpUriRequest request =
+          RequestBuilder.post(getClient().createUri("/rest/security"))
+              .addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+              .setEntity(entity)
+              .build();
+
+      getClient().execute(request, response -> {
+        StatusLine statusLine = response.getStatusLine();
+        if (HttpStatus.SC_OK != statusLine.getStatusCode()) {
+          fail("Failed to enable the security of the GraphDB instance due to: " + statusLine);
+        }
+        return response;
+      });
+    } catch (IOException ioe) {
+      fail("Failed to enable the security of the GraphDB instance.");
+    }
+  }
 
   /**
    * Provides instance of {@link RefineClient}.
@@ -49,15 +120,41 @@ public abstract class IntegrationTest {
    * @return refine client
    */
   protected RefineClient getClient() {
+    return isSecurityEnabled ? getSecuredRefineClient() : getRefineClient();
+  }
+
+  private RefineClient getSecuredRefineClient() {
+    if (securedRefineClient == null) {
+      try {
+        HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
+        BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("admin", "root"));
+        return RefineClients.securityAware(httpHost.toURI(), provider);
+      } catch (URISyntaxException uriExc) {
+        throw new RuntimeException("Failed to create secured refine client.", uriExc);
+      }
+    }
+    return securedRefineClient;
+  }
+
+  private RefineClient getRefineClient() {
     if (refineClient == null) {
       try {
         HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
-        refineClient = RefineClients.standard(httpHost.toURI());
+        return RefineClients.standard(httpHost.toURI());
       } catch (URISyntaxException uriExc) {
         throw new RuntimeException("Failed to create refine client.", uriExc);
       }
     }
-
     return refineClient;
+  }
+
+  /**
+   * Contains switch options.
+   *
+   * @author Antoniy Kunchev
+   */
+  public enum Turn {
+    ON, OFF
   }
 }

--- a/src/test/java/com/ontotext/refine/client/SecuredExportIntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/SecuredExportIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.ontotext.refine.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.command.create.CreateProjectResponse;
+import com.ontotext.refine.client.command.delete.DeleteProjectResponse;
+import com.ontotext.refine.client.command.rdf.ExportRdfResponse;
+import com.ontotext.refine.client.command.rdf.ResultFormat;
+import com.ontotext.refine.client.util.RdfTestUtils;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests related to export commands. The test contains different tests which are
+ * executing their own scenario and verifying the result. The scenarios are combining execution of
+ * different commands. The tests is using real secured GraphDB with OntoRefine instance.
+ *
+ * @author Antoniy Kunchev
+ * @see IntegrationTest
+ */
+class SecuredExportIntegrationTest extends CommandIntegrationTest {
+
+  private static final String RESTAURANTS_CSV = "integration/reduced_netherlands_restaurants.csv";
+
+  // enables the security functionalities for the GDB and the client
+  private SecuredExportIntegrationTest() {
+    security(Turn.ON);
+  }
+
+  /**
+   * Note the scenario uses reduced dataset in order to complete the operations quickly!
+   *
+   * <p>Scenario 1:<br>
+   * <br>
+   * 1. Creates project with name 'Scenario-1-{test-class-name}' using the
+   * 'reduced_netherlands_resturants.csv'<br>
+   * 4. Export the data in RDF format with specific SPARQL query<br>
+   * 5. Delete the project
+   */
+  @Test
+  void exportRdfUsingSparql() throws Exception {
+    String projectName = "Scenario-1-" + SecuredExportIntegrationTest.class.getSimpleName();
+    CreateProjectResponse createResponse = createProject(projectName, RESTAURANTS_CSV);
+    String projectId = createResponse.getProjectId();
+    assertNotNull(projectId);
+
+    waitForProcessesCompletion(projectId);
+
+    String expectedFilePath =
+        "/integration/expected/scenario_1_reduced_netherlands_restaurants_exportRdfUsingSparql.ttl";
+    InputStream expected = getClass().getResourceAsStream(expectedFilePath);
+
+    ExportRdfResponse exportRdfResponse = exportAsRdfUsingSparql(projectId);
+
+    boolean areEqual =
+        RdfTestUtils.compareAsRdf(
+            expected,
+            new ByteArrayInputStream(exportRdfResponse.getResult().getBytes()),
+            RDFFormat.TURTLE);
+
+    assertTrue("The expected result different then the acual one.", areEqual);
+
+    DeleteProjectResponse deleteResponse = deleteProject(projectId);
+    assertEquals(ResponseCode.OK, deleteResponse.getCode());
+  }
+
+  private ExportRdfResponse exportAsRdfUsingSparql(String projectId) throws IOException {
+    String query = IOUtils.resourceToString(
+        "/integration/netherlands_restaurants_construct_query.sparql",
+        StandardCharsets.UTF_8);
+    return RefineCommands
+        .exportRdfUsingSparql()
+        .setProject(projectId)
+        .setFormat(ResultFormat.TURTLE)
+        .setQuery(query)
+        .setRepository(REPO_NAME)
+        .build()
+        .execute(getClient());
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/rdf/ExportRdfCommandTest.java
@@ -24,11 +24,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
 /**
- * Test for {@link ExportRdfCommand}.
+ * Test for {@link DefaultExportRdfCommand}.
  *
  * @author Antoniy Kunchev
  */
-class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, ExportRdfCommand> {
+class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, DefaultExportRdfCommand> {
 
   @Captor
   private ArgumentCaptor<HttpUriRequest> requestCaptor;
@@ -41,7 +41,7 @@ class ExportRdfCommandTest extends BaseCommandTest<ExportRdfResponse, ExportRdfC
   }
 
   @Override
-  protected ExportRdfCommand command() {
+  protected DefaultExportRdfCommand command() {
     return RefineCommands.exportRdf()
         .setProject(PROJECT_ID)
         .setMapping(mapping)

--- a/src/test/java/com/ontotext/refine/client/util/RdfTestUtils.java
+++ b/src/test/java/com/ontotext/refine/client/util/RdfTestUtils.java
@@ -1,0 +1,66 @@
+package com.ontotext.refine.client.util;
+
+import java.io.InputStream;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+
+/**
+ * Test utility that contains RDF data processing logic.
+ *
+ * @author Antoniy Kunchev
+ */
+public class RdfTestUtils {
+
+  private RdfTestUtils() {
+    // test utility
+  }
+
+  /**
+   * Compares given RDF data streams. Useful when there are generated blank nodes.<br>
+   * The method consumes the provided streams.
+   *
+   * @param expected path to a file containing the expected data
+   * @param actual path to a file containing the actual data
+   * @param format of the data
+   * @return <code>true</code> if the files are producing the same semantic data, <code>false</code>
+   *         otherwise
+   * @throws AssertionError when error occurs during the comparison process
+   */
+  public static boolean compareAsRdf(InputStream expected, InputStream actual, RDFFormat format)
+      throws AssertionError {
+    try (InputStream eis = expected; InputStream ais = actual) {
+      Model expectedModel = Rio.parse(expected, "", format);
+
+      Model actualModel = Rio.parse(actual, "", format);
+      return Models.isomorphic(expectedModel, actualModel);
+    } catch (Exception exc) {
+      throw new AssertionError("Failed to compare the provided files due to: " + exc.getMessage());
+    }
+  }
+
+  /**
+   * Compares given RDF data files. Useful when there are generated blank nodes.
+   *
+   * @param expected path to a file containing the expected data
+   * @param actual path to a file containing the actual data
+   * @param format of the data
+   * @return <code>true</code> if the files are producing the same semantic data, <code>false</code>
+   *         otherwise
+   * @throws AssertionError when error occurs during the comparison process
+   */
+  public static boolean compareAsRdf(String expected, String actual, RDFFormat format)
+      throws AssertionError {
+    try (InputStream expectedIs = getResource(expected);
+        InputStream actualIs = getResource(actual)) {
+      return compareAsRdf(expectedIs, actualIs, format);
+    } catch (Exception exc) {
+      throw new AssertionError("Failed to compare the provided files due to: " + exc.getMessage());
+    }
+  }
+
+  private static InputStream getResource(String expected) {
+    return RdfTestUtils.class.getClassLoader().getResourceAsStream(expected);
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/util/mappings/MappingsNormalizerTest.java
+++ b/src/test/java/com/ontotext/refine/client/util/mappings/MappingsNormalizerTest.java
@@ -1,0 +1,90 @@
+package com.ontotext.refine.client.util.mappings;
+
+import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test for {@link MappingsNormalizer}.
+ *
+ * @author Antoniy Kunchev
+ */
+class MappingsNormalizerTest {
+
+  private static final JsonNode EXPECTED_FOR_RDF_EXPORT =
+      toJson(loadResource("expected/forRdfExport_mappings.json"));
+
+  private static final JsonNode EXPECTED_FOR_APPLY_OPERATIONS =
+      toJson(loadResource("expected/forApplyOperations_mappings.json"));
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "forRdfExport_mappings.json",
+      "forRdfExport_operations.json",
+      "forRdfExport_project-models.json"})
+  void forRdfExport(String resource) {
+    String mappings = loadResource(resource);
+
+    String actual = MappingsNormalizer.forRdfExport(mappings);
+
+    assertEquals(EXPECTED_FOR_RDF_EXPORT, toJson(actual));
+  }
+
+  @Test
+  void forRdfExport_emptyJson() {
+    assertNull(MappingsNormalizer.forRdfExport("{}"));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void forRdfExport_emptyOrNullArg(String input) {
+    assertNull(MappingsNormalizer.forRdfExport(input));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void forApplyOperations_emptyOrNullArg(String input) {
+    assertEquals(input, MappingsNormalizer.forApplyOperations(input));
+  }
+
+  @Test
+  void forApplyOperations_projectModelsJson() {
+    String mappings = loadResource("forApplyOperations_mapping.json");
+
+    String actual = MappingsNormalizer.forApplyOperations(mappings);
+
+    assertEquals(EXPECTED_FOR_APPLY_OPERATIONS, toJson(actual));
+  }
+
+  private static JsonNode toJson(String value) {
+    try {
+      return JSON_PARSER.parseJson(value);
+    } catch (RefineException re) {
+      fail("Failed to convert value to JSON.", re);
+      return null;
+    }
+  }
+
+  private static String loadResource(String resource)  {
+    try {
+      return IOUtils.toString(
+          MappingsNormalizerTest.class.getClassLoader()
+              .getResourceAsStream("mappings-normalizer/" + resource),
+          StandardCharsets.UTF_8);
+    } catch (IOException ioe) {
+      fail("Failed to load resource: " + resource, ioe);
+      return null;
+    }
+  }
+}

--- a/src/test/resources/integration/config.ttl
+++ b/src/test/resources/integration/config.ttl
@@ -1,0 +1,55 @@
+#
+# RDF4J configuration template for a GraphDB EE worker repository
+#
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix rep: <http://www.openrdf.org/config/repository#>.
+@prefix sr: <http://www.openrdf.org/config/repository/sail#>.
+@prefix sail: <http://www.openrdf.org/config/sail#>.
+@prefix owlim: <http://www.ontotext.com/trree/owlim#>.
+@prefix shacl: <http://rdf4j.org/config/sail/shacl#>.
+
+[] a rep:Repository ;
+    rep:repositoryID "integration-tests" ;
+    rdfs:label "" ;
+    rep:repositoryImpl [
+        rep:repositoryType "owlim:ReplicationClusterWorker" ;
+        rep:delegate [
+            rep:repositoryType "owlim:MonitorRepository" ;
+            sr:sailImpl [
+                sail:sailType "rdf4j:ShaclSail";
+                shacl:validationEnabled "true" ;
+                shacl:logValidationPlans "false" ;
+                shacl:logValidationViolations "false" ;
+                shacl:parallelValidation "true" ;
+                shacl:globalLogValidationExecution "false" ;
+                shacl:cacheSelectNodes "true" ;
+                shacl:undefinedTargetValidatesAllSubjects "false" ;
+                shacl:ignoreNoShapesLoadedException "false" ;
+                shacl:performanceLogging "false" ;
+                shacl:rdfsSubClassReasoning "true" ;
+                sail:delegate [
+                  sail:sailType "owlimClusterWorker:Sail";
+                  owlim:owlim-license "" ;
+                  owlim:base-URL "http://example.org/owlim#" ;
+                  owlim:defaultNS "" ;
+                  owlim:entity-index-size "10000000" ;
+                  owlim:entity-id-size  "32" ;
+                  owlim:imports "" ;
+                  owlim:repository-type "file-repository" ;
+                  owlim:ruleset "empty" ;
+                  owlim:storage-folder "storage" ;
+                  owlim:enable-context-index "false" ;
+                  owlim:enablePredicateList "true" ;
+                  owlim:in-memory-literal-properties "true" ;
+                  owlim:enable-literal-index "true" ;
+                  owlim:check-for-inconsistencies "false" ;
+                  owlim:disable-sameAs  "true" ;
+                  owlim:query-timeout  "0" ;
+                  owlim:query-limit-results  "0" ;
+                  owlim:throw-QueryEvaluationException-on-timeout "false" ;
+                  owlim:read-only "false" ;
+                  owlim:nonInterpretablePredicates "http://www.w3.org/2000/01/rdf-schema#label;http://www.w3.org/1999/02/22-rdf-syntax-ns#type;http://www.ontotext.com/owlim/ces#gazetteerConfig;http://www.ontotext.com/owlim/ces#metadataConfig" ;
+                ]
+            ]
+        ]
+    ].

--- a/src/test/resources/integration/expected/scenario_1_reduced_netherlands_restaurants_exportRdfUsingSparql.ttl
+++ b/src/test/resources/integration/expected/scenario_1_reduced_netherlands_restaurants_exportRdfUsingSparql.ttl
@@ -1,0 +1,559 @@
+@prefix mapper: <http://www.ontotext.com/mapper/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix amsterdam: <https://data/amsterdam/nl/resource/> .
+@prefix sf: <http://www.opengis.net/ont/sf#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rdf4j: <http://rdf4j.org/schema/rdf4j#> .
+@prefix sesame: <http://www.openrdf.org/schema/sesame#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix fn: <http://www.w3.org/2005/xpath-functions#> .
+
+<https://data/amsterdam/nl/resource/restaurant/669d7d82-8962-4e88-b2e1-7b8706633aa0>
+  a schema:Restaurant;
+  schema:title "Smits Noord-Zuid Hollandsch Koffiehuis", "Smits Noord-Zuid Hollandsch Koffiehuis"@english;
+  schema:description "Het Smits Koffiehuis ontleent haar ontstaan aan de stoomtram die de verbinding onderhield met Amsterdam naar het noorden van de provincie en is in 1919 gebouwd. Nu is er een restaurant en een koffiebar. Ook is hier een informatiekantoor van Amsterdam Marketing gehuisvest.";
+  schema:latitude "0"^^xsd:float;
+  amsterdam:zipcode "1012 AB";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20101122/ec8faec5-5cd5-43d6-b0fa-eb0dab65e278.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/669d7d82-8962-4e88-b2e1-7b8706633aa0>;
+  amsterdam:uniquelocation _:node1;
+  amsterdam:valuelocation _:node2 .
+
+<https://data/amsterdam/nl/resource/geometry/669d7d82-8962-4e88-b2e1-7b8706633aa0>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node1 amsterdam:address "Stationsplein 10" .
+
+_:node2 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/8d9eb314-4433-477e-84b7-35a3552b6fbe>
+  a schema:Restaurant;
+  schema:title "Afrikaans Restaurant Kilimanjaro", "African Restaurant Kilimanjaro"@english;
+  schema:description "Een Afrikaans (Senegal, Ghana, Zuid-Afrika e.a.) restaurant tegenover NEMO, dichtbij het Waterlooplein. De menukaart is voor degenen die niet van alledaags eten houden. Je kunt hier een echte smaaksensatie beleven.";
+  schema:latitude "1"^^xsd:float;
+  amsterdam:zipcode "1011 VB";
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/8d9eb314-4433-477e-84b7-35a3552b6fbe>;
+  amsterdam:uniquelocation _:node3;
+  amsterdam:valuelocation _:node4 .
+
+<https://data/amsterdam/nl/resource/geometry/8d9eb314-4433-477e-84b7-35a3552b6fbe>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node3 amsterdam:address "Rapenburgerplein 6 HS" .
+
+_:node4 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/ca0e88a6-5cd2-4dc0-8d6a-4273f84721bd>
+  a schema:Restaurant;
+  schema:title "Akbar Indian Restaurant", "Akbar Indian Restaurant"@english;
+  schema:description "Een chique restaurant, ingericht in Moghul stijl, waarin de gast het gevoel krijgt dat hij in India aan het eten is. De keuken serveert gerechten afkomstig uit Noord India/Punjabi stijl.";
+  schema:latitude "2"^^xsd:float;
+  amsterdam:zipcode "1017 PV";
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/ca0e88a6-5cd2-4dc0-8d6a-4273f84721bd>;
+  amsterdam:uniquelocation _:node5;
+  amsterdam:valuelocation _:node6 .
+
+<https://data/amsterdam/nl/resource/geometry/ca0e88a6-5cd2-4dc0-8d6a-4273f84721bd>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node5 amsterdam:address "Korte Leidsedwarsstraat 15" .
+
+_:node6 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/adcd917e-a472-4aed-aace-999c95e97006>
+  a schema:Restaurant;
+  schema:title "Alfonso's Mexican Restaurant", "Alfonso's Mexican Restaurant"@english;
+  schema:description "In de Utrechtsestraat in Amsterdam, op slechts vijf minuten loopafstand van het Rembrandtplein, de Kleine Komedie en Carré, tref je Alfonso?s: een authentiek Mexicaans restaurant. Gevestigd in een historisch pand en sinds oktober 1986 heb je de keuze uit de vele, beroemde specialiteiten die Mexico rijk is.  ";
+  schema:latitude "3"^^xsd:float;
+  amsterdam:zipcode "1017 VN";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110124/e888e5d3-c02b-4966-bf0e-64c1510391b9.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110124/d1231e16-bfb6-4120-8f42-c721b50a55dd.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/adcd917e-a472-4aed-aace-999c95e97006>;
+  amsterdam:uniquelocation _:node7;
+  amsterdam:valuelocation _:node8 .
+
+<https://data/amsterdam/nl/resource/geometry/adcd917e-a472-4aed-aace-999c95e97006>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node7 amsterdam:address "Utrechtsestraat 32" .
+
+_:node8 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/8c83496c-0b8b-41f2-987c-21ddb78b2978>
+  a schema:Restaurant;
+  schema:title "Café het Paleis", "Café het Paleis"@english;
+  schema:description "Het café-restaurant Paleis, vlak achter het Paleis op de Dam, is al jaren favoriet vanwege de betaalbare gerechten, maar het is ook een plek om even een drankje te drinken. Studenten komen in dit knusse, moderne tentje na een tentamen, vrouwen na een dagje shoppen en freelancers houden hier een werkbespreking. In de zomer op het prettige terras. Je eet hier taarten, belegde broodjes en pasta?s, salades en soepen.";
+  schema:latitude "4"^^xsd:float;
+  amsterdam:zipcode "1012 RB";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110124/7baf3cbe-8c82-43e7-9813-30dd2ef2bcd2.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/8c83496c-0b8b-41f2-987c-21ddb78b2978>;
+  amsterdam:uniquelocation _:node9;
+  amsterdam:valuelocation _:node10 .
+
+<https://data/amsterdam/nl/resource/geometry/8c83496c-0b8b-41f2-987c-21ddb78b2978>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node9 amsterdam:address "Paleisstraat 16" .
+
+_:node10 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/56b1dd7d-4ac3-4e24-826e-cb8b55617f42>
+  a schema:Restaurant;
+  schema:title "Amstel Bar & Brasserie", "Amstel Bar & Brasserie"@english;
+  schema:description "De Amstel Bar & Brasserie is een informele plek voor lunch, diner of late maaltijd na het theaterbezoek. Ook voor cocktails kun je hier terecht. Door de grote ramen en in de zomer op het terras heb je een prachtig uitzicht op de Hogesluis.";
+  schema:latitude "5"^^xsd:float;
+  amsterdam:zipcode "1018 GX";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/e01c5518-4708-447f-9a95-0c78ed847709.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/56b1dd7d-4ac3-4e24-826e-cb8b55617f42>;
+  amsterdam:uniquelocation _:node11;
+  amsterdam:valuelocation _:node12 .
+
+<https://data/amsterdam/nl/resource/geometry/56b1dd7d-4ac3-4e24-826e-cb8b55617f42>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node11 amsterdam:address "Professor Tulpplein 1" .
+
+_:node12 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/2760a2d8-0404-45df-aa6e-fd88c602d5b9>
+  a schema:Restaurant;
+  schema:title "Caffe Ristretto - Lunchrestaurant & Café", "Caffe Ristretto ? Lunch restaurant & Café"@english;
+  schema:description "Caffe Ristretto bevindt zich op de bovenste etage van winkelcentrum Magna Plaza. Het café biedt een prachtig uitzicht op de binnenkant van het monumentale pand. De combinatie van het moderne interieur, de kleurrijke schilderijen en de ligging in het mooie gebouw geven het café een internationale sfeer. Naast veel koffiespecialiteiten heeft het café een uitgebreide lunchkaart met onder andere sandwiches, soepen, salades en warme gerechten. Daarbij is er een ruim assortiment kranten en tijdschriften.";
+  schema:latitude "6"^^xsd:float;
+  amsterdam:zipcode "1012 SJ";
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/2760a2d8-0404-45df-aa6e-fd88c602d5b9>;
+  amsterdam:uniquelocation _:node13;
+  amsterdam:valuelocation _:node14 .
+
+<https://data/amsterdam/nl/resource/geometry/2760a2d8-0404-45df-aa6e-fd88c602d5b9>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node13 amsterdam:address "Nieuwezijds Voorburgwal 182" .
+
+_:node14 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/17d5d8e4-80c9-459a-8dd2-c59a1eb87618>
+  a schema:Restaurant;
+  schema:title "Café Restaurant de Passage", "Café Restaurant de Passage"@english;
+  schema:description "Café Restaurant de Passage is een authentiek Amsterdams restaurant, gelegen aan de Dam/Nieuwendijk en is gespecialiseerd in Nederlandse en mediteraanse gerechten.";
+  schema:latitude "7"^^xsd:float;
+  amsterdam:zipcode "1012 MX";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/b47aeedc-922a-4460-9851-dfce14341359.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/17d5d8e4-80c9-459a-8dd2-c59a1eb87618>;
+  amsterdam:uniquelocation _:node15;
+  amsterdam:valuelocation _:node16 .
+
+<https://data/amsterdam/nl/resource/geometry/17d5d8e4-80c9-459a-8dd2-c59a1eb87618>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node15 amsterdam:address "Nieuwendijk 224" .
+
+_:node16 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/6c176a7d-04ba-4b4f-83dd-eab89961f971>
+  a schema:Restaurant;
+  schema:title "De Stijl", "De Stijl"@english;
+  schema:description "In Design Hotel Artemis huist café-restaurant ?De Stijl? met een riant terras aan een grote vijver. Inspiratiebron voor deze locatie was het gelijknamige kunstenaarscollectief De Stijl, met als bekendste vertegenwoordiger Piet Mondriaan.  ";
+  schema:latitude "8"^^xsd:float;
+  amsterdam:zipcode "1066 EP";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/4a6b5681-afa0-49e4-a16b-6f9db9d19522.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/6c176a7d-04ba-4b4f-83dd-eab89961f971>;
+  amsterdam:uniquelocation _:node17;
+  amsterdam:valuelocation _:node18 .
+
+<https://data/amsterdam/nl/resource/geometry/6c176a7d-04ba-4b4f-83dd-eab89961f971>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node17 amsterdam:address "John M. Keynesplein 2" .
+
+_:node18 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/9792d7d2-6aa9-4317-b9ff-71d673084e61>
+  a schema:Restaurant;
+  schema:title "Cinema Paradiso", "Cinema Paradiso"@english;
+  schema:description "Cinema Paradiso is inmiddels al wat jaren favoriet bij de incrowd van de stad. In een oude bioscoop op de Westerstraat eet je geen chique Italiaanse gerechten, maar juist perfecte pizza uit de houtoven, pasta?s en antipasti.";
+  schema:latitude "9"^^xsd:float;
+  amsterdam:zipcode "1015 MR";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/f0a1e8d4-5d0d-4730-91b6-cc5686eef9be.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/9792d7d2-6aa9-4317-b9ff-71d673084e61>;
+  amsterdam:uniquelocation _:node19;
+  amsterdam:valuelocation _:node20 .
+
+<https://data/amsterdam/nl/resource/geometry/9792d7d2-6aa9-4317-b9ff-71d673084e61>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node19 amsterdam:address "Westerstraat 186" .
+
+_:node20 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/586d2ccd-de3d-4354-86d2-3b37a2820d39>
+  a schema:Restaurant;
+  schema:title "De Bijenkorf Kitchen", "The Bijenkorf Kitchen"@english;
+  schema:description "De Bijenkorf Amsterdam is een inspirerend, trendsettend en dynamisch warenhuis dat zich onderscheidt door een brede assortimentskeuze, vernieuwende thema's en evenementen. Tot het assortiment van de Bijenkorf behoren internationale topmerken en eigen merken op het gebied van mode, cosmetica, accessoires, wonen, media en reizen.  ";
+  schema:latitude "10"^^xsd:float;
+  amsterdam:zipcode "1012 JS";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/3bfba3c3-d850-45d2-aa05-92623d6a10b7.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110125/b9162fd5-cd0b-4258-b797-d8f01627cf47.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110125/c19fe1ad-9321-438e-b501-671be4479ab7.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110125/1d558146-ec71-45ac-83a7-f26dea1df7a4.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/586d2ccd-de3d-4354-86d2-3b37a2820d39>;
+  amsterdam:uniquelocation _:node21;
+  amsterdam:valuelocation _:node22 .
+
+<https://data/amsterdam/nl/resource/geometry/586d2ccd-de3d-4354-86d2-3b37a2820d39>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node21 amsterdam:address "Dam 1" .
+
+_:node22 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/81fc539d-4d17-4ffe-8e6c-e87de32ace78>
+  a schema:Restaurant;
+  schema:title "De Kroonprins", "The Kroonprins"@english;
+  schema:description "De Kroonprins is een oud-Hollands restaurant, gelegen tegenover het Centraal Station van Amsterdam.  ";
+  schema:latitude "11"^^xsd:float;
+  amsterdam:zipcode "1012 AC";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110125/24cf5ad2-b9fc-4da9-89ed-1f70ed510d38.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/81fc539d-4d17-4ffe-8e6c-e87de32ace78>;
+  amsterdam:uniquelocation _:node23;
+  amsterdam:valuelocation _:node24 .
+
+<https://data/amsterdam/nl/resource/geometry/81fc539d-4d17-4ffe-8e6c-e87de32ace78>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node23 amsterdam:address "Prins Hendrikkade 52-57" .
+
+_:node24 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/43ad34d9-3571-4721-9382-ffe860fe8755>
+  a schema:Restaurant;
+  schema:title "Restaurant Indrapura", "Restaurant Indrapura"@english;
+  schema:description "De stijl van toen en in de sfeer van vandaag, dat is wat restaurant Indrapura biedt. Het restaurant ligt centraal, aan het Rembrandtplein en op loopafstand van de Stopera en Theater Carré. Er is een aparte ruimte voor grotere gezelschappen. De catering van Indrapura is toegespitst op de persoonlijke wensen, dus behoren vegetarische gerechten (zowel á la carte als rijsttafels) uiteraard ook tot de mogelijkheden. Restaurant Indrapura werkt volgens de HACCP hygiene normen.";
+  schema:latitude "12"^^xsd:float;
+  amsterdam:zipcode "1017 CV";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110127/06f919d6-5d92-423f-8972-d2fdfe54a373.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/43ad34d9-3571-4721-9382-ffe860fe8755>;
+  amsterdam:uniquelocation _:node25;
+  amsterdam:valuelocation _:node26 .
+
+<https://data/amsterdam/nl/resource/geometry/43ad34d9-3571-4721-9382-ffe860fe8755>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node25 amsterdam:address "Rembrandtplein 42" .
+
+_:node26 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/07eeee9b-9d1d-40a3-afe3-2119982dda85>
+  a schema:Restaurant;
+  schema:title "D'Vijf Broers", "D'Vijf Broers"@english;
+  schema:description "D'Vijf Broers is een trendy en intiem restaurant waar je tegen kleine prijzen smaakvol kunt lunchen en dineren.";
+  schema:latitude "13"^^xsd:float;
+  amsterdam:zipcode "1544 BG";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110127/3f14dad7-de7e-4cd0-8242-ecf012d47f3b.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110127/492817f5-4984-4fbc-871e-85b4dba19d86.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110127/560cffd2-5e2b-4b22-87bf-bf49f4739c43.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/07eeee9b-9d1d-40a3-afe3-2119982dda85>;
+  amsterdam:uniquelocation _:node27;
+  amsterdam:valuelocation _:node28 .
+
+<https://data/amsterdam/nl/resource/geometry/07eeee9b-9d1d-40a3-afe3-2119982dda85>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node27 amsterdam:address "Lagedijk 32-34" .
+
+_:node28 amsterdam:city "ZAANDIJK" .
+
+<https://data/amsterdam/nl/resource/restaurant/e526f228-83f7-4a81-9cda-0d137d1ef2db>
+  a schema:Restaurant;
+  schema:title "Madre Maria", "Madre Maria"@english;
+  schema:description "Madre Maria is een Argentijns grill restaurant op nog geen minuut lopen vanaf het Centraal Station. De specialiteit van Madre Maria is vlees van de grill. Maar ook kunt u bij Madre Maria terecht voor een kinder- of vegetarisch menu.";
+  schema:latitude "14"^^xsd:float;
+  amsterdam:zipcode "1012 ML";
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/e526f228-83f7-4a81-9cda-0d137d1ef2db>;
+  amsterdam:uniquelocation _:node29;
+  amsterdam:valuelocation _:node30 .
+
+<https://data/amsterdam/nl/resource/geometry/e526f228-83f7-4a81-9cda-0d137d1ef2db>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node29 amsterdam:address "Nieuwendijk 40" .
+
+_:node30 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/40c53f2a-cc32-4007-9e86-dd15b7cd1df7>
+  a schema:Restaurant;
+  schema:title "Matias", "Matias"@english;
+  schema:description "Matias heeft de uitstraling van een echte Mexicaanse cantina: gezellig, sfeervol en betaalbaar. In een kleurrijke ambiance serveert het vriendelijke personeel allerlei soorten Mexicaanse gerechten, hapjes en drankjes. ";
+  schema:latitude "15"^^xsd:float;
+  amsterdam:zipcode "1017 PX";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110127/2b579a66-f03e-4f5c-9003-5950bc3208ee.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110127/9f37cf3b-ebe3-4711-90ce-245950f23e4a.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/40c53f2a-cc32-4007-9e86-dd15b7cd1df7>;
+  amsterdam:uniquelocation _:node31;
+  amsterdam:valuelocation _:node32 .
+
+<https://data/amsterdam/nl/resource/geometry/40c53f2a-cc32-4007-9e86-dd15b7cd1df7>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node31 amsterdam:address "Korte Leidsedwarsstraat 95" .
+
+_:node32 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/a9e3ddff-6863-427f-a049-f243974d8586>
+  a schema:Restaurant;
+  schema:title "Girassol", "Girassol"@english;
+  schema:description "Een klein familiar restaurant, simpel, vriendelijk, gemoedelijk en absoluut niet formeel. Af en toe worden er fado-avonden georganiseerd (Portugese zang). In de zomer is er vanaf 12 uur aan de Amstel een terras.";
+  schema:latitude "16"^^xsd:float;
+  amsterdam:zipcode "1091 ES";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110127/2cd4894e-5ece-4d65-80a5-a09607c2314a.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/a9e3ddff-6863-427f-a049-f243974d8586>;
+  amsterdam:uniquelocation _:node33;
+  amsterdam:valuelocation _:node34 .
+
+<https://data/amsterdam/nl/resource/geometry/a9e3ddff-6863-427f-a049-f243974d8586>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node33 amsterdam:address "Weesperzijde 135" .
+
+_:node34 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/a6e96853-6403-49fa-9d0e-39eeff555a56>
+  a schema:Restaurant;
+  schema:title "Restaurant Majestic", "Restaurant Majestic"@english;
+  schema:description "Gelegen aan het belangrijkste plein van Nederland, direct naast het warenhuis de Bijenkorf en in de directe nabijheid van het koninklijk paleis, Madame Tussauds, de Kalverstraat, de Amsterdamse wallen en vele hotels. Als er één café is waarvan de naam perfect past bij het concept, dan is dat wel de Majestic. ";
+  schema:latitude "17"^^xsd:float;
+  amsterdam:zipcode "1012 JS";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/3a139d4a-3a15-42e3-9564-737fe8327c6e.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/2bef9ce4-31f5-4d23-b9d6-c41959d4cb6d.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/a6e96853-6403-49fa-9d0e-39eeff555a56>;
+  amsterdam:uniquelocation _:node35;
+  amsterdam:valuelocation _:node36 .
+
+<https://data/amsterdam/nl/resource/geometry/a6e96853-6403-49fa-9d0e-39eeff555a56>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node35 amsterdam:address "Dam 3-7" .
+
+_:node36 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/e1b97cca-b08a-4639-b56b-1c93d4777b48>
+  a schema:Restaurant;
+  schema:title "Restaurant Mercure Amsterdam Airport", "Restaurant Mercure Amsterdam Airport"@english;
+  schema:description "Modern, licht, qua inrichting. Goede prijs-kwaliteit-verhouding. Ideaal voor nationale ontmoetingen: locatie is aan de A4/A9/A10 en er zijn 350 parkeerplaatsen.";
+  schema:latitude "18"^^xsd:float;
+  amsterdam:zipcode "1066 BW";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/a0312475-5d9b-4722-8636-36987c1b3ff4.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/e1b97cca-b08a-4639-b56b-1c93d4777b48>;
+  amsterdam:uniquelocation _:node37;
+  amsterdam:valuelocation _:node38 .
+
+<https://data/amsterdam/nl/resource/geometry/e1b97cca-b08a-4639-b56b-1c93d4777b48>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node37 amsterdam:address "Oude Haagseweg 20" .
+
+_:node38 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/eafa02c5-812c-49cb-bf41-3571a507c9b7>
+  a schema:Restaurant;
+  schema:title "Palazzo", "Palazzo"@english;
+  schema:description "Voortreffelijk dineren en spectaculair entertainment zijn al sinds mensen heugenis de twee belangrijkste aspecten voor een onvergetelijke avond uit. Voor het tiende jaar combineert Palazzo juist deze aspecten.";
+  schema:latitude "19"^^xsd:float;
+  amsterdam:zipcode "1101 DL";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/4b340cee-da9c-48ec-b28b-001c124be5ed.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/ac104281-bd3c-49f3-b029-4b934dac0f01.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/99cca313-a728-46a2-94cf-bca1704f3785.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/e0277c11-1294-4918-bc35-d373c4ff5d4e.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/088087e0-d211-43dd-a929-be534573efea.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/eafa02c5-812c-49cb-bf41-3571a507c9b7>;
+  amsterdam:uniquelocation _:node39;
+  amsterdam:valuelocation _:node40 .
+
+<https://data/amsterdam/nl/resource/geometry/eafa02c5-812c-49cb-bf41-3571a507c9b7>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node39 amsterdam:address "Arena boulevard 61-75" .
+
+_:node40 amsterdam:city "AMSTERDAM ZUIDOOST" .
+
+<https://data/amsterdam/nl/resource/restaurant/2a3ba197-69ab-4be0-931e-1a57f5d14242>
+  a schema:Restaurant;
+  schema:title "Panagia", "Panagia"@english;
+  schema:description "Geniet in dit authentieke Griekse restaurant, gelegen in het centrum van Amsterdam dichtbij het Centraal Station. In de open keuken wordt dagelijks gekookt met verse groente en speciale Griekse ingrediënten. De typische Griekse gerechten zoals Moussaka worden op originele wijze bereid en geserveerd.";
+  schema:latitude "20"^^xsd:float;
+  amsterdam:zipcode "1012 MA";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/b2144cbd-a0e4-447f-b45c-1cc3df85ab7d.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/efc80ad3-512e-4e41-9554-d976e54b1832.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/113e9a12-456a-4415-a775-bbd6d2ace370.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/5e3f2511-95bb-471a-981e-bc78e800e7d6.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/2a3ba197-69ab-4be0-931e-1a57f5d14242>;
+  amsterdam:uniquelocation _:node41;
+  amsterdam:valuelocation _:node42 .
+
+<https://data/amsterdam/nl/resource/geometry/2a3ba197-69ab-4be0-931e-1a57f5d14242>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node41 amsterdam:address "Nieuwendijk 31" .
+
+_:node42 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/215f8ef9-44f2-421b-8f0e-210153e4a25a>
+  a schema:Restaurant;
+  schema:title "Patisserie Pompadour", "Pompadour"@english;
+  schema:description "Chocolaterie en lunchroom.";
+  schema:latitude "21"^^xsd:float;
+  amsterdam:zipcode "1017 GR";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/5bb15ec5-a497-493c-b0e3-0cc5fc3b3698.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/215f8ef9-44f2-421b-8f0e-210153e4a25a>;
+  amsterdam:uniquelocation _:node43;
+  amsterdam:valuelocation _:node44 .
+
+<https://data/amsterdam/nl/resource/geometry/215f8ef9-44f2-421b-8f0e-210153e4a25a>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node43 amsterdam:address "Kerkstraat 148" .
+
+_:node44 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/28e4f3e5-13d9-4655-9032-e644ac310d6c>
+  a schema:Restaurant;
+  schema:title "Rain Restaurant Bar Club", "Rain Restaurant Bar Club"@english;
+  schema:description "Club Rain is een club, bar en restaurant aan het Rembrandtplein in Amsterdam. Je kunt hier terecht voor een bijkletssessie, een diner of een avondje dansen.";
+  schema:latitude "22"^^xsd:float;
+  amsterdam:zipcode "1017 CV";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/e083c5e6-ffb5-488b-a618-bd06c6e73251.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/20c3cfd1-fd92-4db3-a6eb-c117188a7b64.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/52848ce7-e464-4d77-b529-581ce22ac379.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110128/b2c532d8-a56f-49e0-9a79-e6f9a6cea939.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/28e4f3e5-13d9-4655-9032-e644ac310d6c>;
+  amsterdam:uniquelocation _:node45;
+  amsterdam:valuelocation _:node46 .
+
+<https://data/amsterdam/nl/resource/geometry/28e4f3e5-13d9-4655-9032-e644ac310d6c>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node45 amsterdam:address "Rembrandtplein 44" .
+
+_:node46 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/ba2df677-faad-427a-942f-25fc69869af2>
+  a schema:Restaurant;
+  schema:title "Restaurant Neva", "Restaurant Neva"@english;
+  schema:description "Café-restaurant Neva is gelegen in de Hermitage Amsterdam. Een prachtig vormgegeven horecalocatie met stijl voor een snelle cappuccino, een goed glas wijn, een kleine of uitgebreide lunch of een chic diner. ";
+  schema:latitude "23"^^xsd:float;
+  amsterdam:zipcode "1018 EJ";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110128/da39c545-4f7b-49d1-a48c-46f1110d794b.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/ba2df677-faad-427a-942f-25fc69869af2>;
+  amsterdam:uniquelocation _:node47;
+  amsterdam:valuelocation _:node48 .
+
+<https://data/amsterdam/nl/resource/geometry/ba2df677-faad-427a-942f-25fc69869af2>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node47 amsterdam:address "Amstel 51" .
+
+_:node48 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/0dc430b8-f08c-47c9-beac-318bf1d0d6e5>
+  a schema:Restaurant;
+  schema:title "Restaurant Syriana", "Restaurant Syriana"@english;
+  schema:description "Dit Syrische-Libanese restaurant blijft mensen verrassen. In de keuken wordt gewerkt aan eigentijdse hoofdgerechten met alleen verse producten. Het restaurant is sfeervol ingericht en regelmatig zijn er artiesten met live muziek. In de serre kan ook gegeten worden met uitzicht op de molen van Sloten.";
+  schema:latitude "24"^^xsd:float;
+  amsterdam:zipcode "1066 EZ";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110131/0817d949-bff8-4d4a-81d5-d2d2a950aa20.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110131/201d3e46-365b-4229-8e71-f516a124c91a.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110131/2a941f2f-6078-4f81-b8b1-d4d097a2e420.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/20110131/40226334-cc13-4a40-932a-17265e089dc1.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/0dc430b8-f08c-47c9-beac-318bf1d0d6e5>;
+  amsterdam:uniquelocation _:node49;
+  amsterdam:valuelocation _:node50 .
+
+<https://data/amsterdam/nl/resource/geometry/0dc430b8-f08c-47c9-beac-318bf1d0d6e5>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node49 amsterdam:address "Akersluis 8" .
+
+_:node50 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/fd2ed47c-627c-40da-95b1-dfdca832be62>
+  a schema:Restaurant;
+  schema:title "Rose's Cantina", "Rose's Cantina"@english;
+  schema:description "Midden in de bruisende Reguliersdwarsstraat in Amsterdam zit Rose's Cantina. De perfecte plek voor Mexicaans eten en cocktails. ";
+  schema:latitude "25"^^xsd:float;
+  amsterdam:zipcode "1017 BM";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/fd/fd2ed47c-627c-40da-95b1-dfdca832be62/36fad538-b5a6-44a5-a466-7f4ad1a6001c.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/fd/fd2ed47c-627c-40da-95b1-dfdca832be62/3b276ee1-961b-4407-98c3-751902109404.jpg%2Chttps%3A//media.iamsterdam.com/ndtrc/Images/fd/fd2ed47c-627c-40da-95b1-dfdca832be62/62df80ff-6a1e-4ae7-82d5-4b2342f8d833.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/fd2ed47c-627c-40da-95b1-dfdca832be62>;
+  amsterdam:uniquelocation _:node51;
+  amsterdam:valuelocation _:node52 .
+
+<https://data/amsterdam/nl/resource/geometry/fd2ed47c-627c-40da-95b1-dfdca832be62>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node51 amsterdam:address "Reguliersdwarsstraat 38" .
+
+_:node52 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/d82a6238-0837-43c7-bf66-851fa1895707>
+  a schema:Restaurant;
+  schema:title "Tempo Doeloe", "Tempo Doeloe"@english;
+  schema:description "Tempo Doeloe in de Utrechtsestraat is een van de beste Indonesische restaurants van de stad. In de keuken wordt alleen met verse, authentieke ingrediënten gewerkt en op de menukaart staan voornamelijk klassiekers en verschillende soorten rijsttafels. Ter begeleiding hebben ze hier uitstekende wijnen. Omdat het restaurant zo klein is, moet je als gast eerst even reserveren en aanbellen alvorens je naar binnen kunt.";
+  schema:latitude "26"^^xsd:float;
+  amsterdam:zipcode "1017 VJ";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110131/8b707d69-c43a-4ad4-8464-b9ed5a4d333b.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/d82a6238-0837-43c7-bf66-851fa1895707>;
+  amsterdam:uniquelocation _:node53;
+  amsterdam:valuelocation _:node54 .
+
+<https://data/amsterdam/nl/resource/geometry/d82a6238-0837-43c7-bf66-851fa1895707>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node53 amsterdam:address "Utrechtsestraat 75" .
+
+_:node54 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/672b71ac-b3e7-42c8-ad73-39f54fab6957>
+  a schema:Restaurant;
+  schema:title "Restaurant The College Hotel", "Restaurant The College Hotel"@english;
+  schema:description "In een verbouwde 19e eeuwse schoolgymzaal zit het restaurant van het College Hotel. Net als de rest van het hotel is ook alles hier in stijl. In de lichte, open ruimte eet je prachtige, speelse gerechten waarbij de Hollandse keuken in een nieuw jasje is gestoken. Vergeet niet dat dit, net als de rest van het hotel, een trainingcentrum is voor horecastudenten. Er kan af en toe iets misgaan, daar leren ze alleen maar van. De bar van het hotel is ook voor Amsterdammers een populaire hang out.";
+  schema:latitude "27"^^xsd:float;
+  amsterdam:zipcode "1071 VE";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110131/da8a72ae-8363-439d-bb06-eff3936593b7.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/672b71ac-b3e7-42c8-ad73-39f54fab6957>;
+  amsterdam:uniquelocation _:node55;
+  amsterdam:valuelocation _:node56 .
+
+<https://data/amsterdam/nl/resource/geometry/672b71ac-b3e7-42c8-ad73-39f54fab6957>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node55 amsterdam:address "Roelof Hartstraat 1" .
+
+_:node56 amsterdam:city "AMSTERDAM" .
+
+<https://data/amsterdam/nl/resource/restaurant/e27ade8b-ec67-4e34-8b71-d61cc17bb2aa>
+  a schema:Restaurant;
+  schema:title "Small Talk Restaurant en Coffee Corner", "Small Talk Restaurant en Coffee Corner"@english;
+  schema:description "Klein en knus restaurant.";
+  schema:latitude "28"^^xsd:float;
+  amsterdam:zipcode "1071 BA";
+  schema:image <http://example/base/https%3A//media.iamsterdam.com/ndtrc/Images/20110131/4e3f604d-0f99-43bd-b076-86bc3afce070.jpg>;
+  geo:hasGeometry <https://data/amsterdam/nl/resource/geometry/e27ade8b-ec67-4e34-8b71-d61cc17bb2aa>;
+  amsterdam:uniquelocation _:node57;
+  amsterdam:valuelocation _:node58 .
+
+<https://data/amsterdam/nl/resource/geometry/e27ade8b-ec67-4e34-8b71-d61cc17bb2aa>
+  a sf:Point;
+  geo:asWKT "<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT ("^^geo:wktLiteral .
+
+_:node57 amsterdam:address "Van Baerlestraat 52" .
+
+_:node58 amsterdam:city "AMSTERDAM" .

--- a/src/test/resources/integration/netherlands_restaurants_construct_query.sparql
+++ b/src/test/resources/integration/netherlands_restaurants_construct_query.sparql
@@ -1,0 +1,39 @@
+BASE <http://example/base/>
+PREFIX mapper: <http://www.ontotext.com/mapper/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <http://schema.org/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX amsterdam: <https://data/amsterdam/nl/resource/>
+PREFIX sf: <http://www.opengis.net/ont/sf#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+CONSTRUCT {
+    ?s1 a schema:Restaurant ;
+        schema:title ?o_title, ?o_title_2 ;
+        schema:description ?o_description ;
+        schema:latitude ?o_latitude ;
+        amsterdam:zipcode ?o_zipcode ;
+        schema:image ?o_image ;
+        geo:hasGeometry ?o_hasGeometry .
+    ?o_hasGeometry a sf:Point ;
+        geo:asWKT ?o_asWKT .
+    ?s1 amsterdam:uniquelocation [amsterdam:address ?o_Adres] .
+    ?s1 amsterdam:valuelocation [amsterdam:city ?o_City] .
+} WHERE {
+    SERVICE <rdf-mapper:ontorefine:#project_placeholder#> {
+        BIND(IRI(mapper:encode_iri(amsterdam:restaurant\/, ?c_Trcid)) as ?s1)
+        BIND(STR(?c_Title) as ?o_title)
+        BIND(STRLANG(?c_TitleEN, "english") as ?o_title_2)
+        BIND(STR(?c_Shortdescription) as ?o_description)
+        (?row_index "value.replace(',','.')") mapper:grel ?o_latitude_grel .
+        BIND(STRDT(?o_latitude_grel, xsd:float) as ?o_latitude)
+        BIND(STR(?c_Zipcode) as ?o_zipcode)
+        BIND(IRI(mapper:encode_iri(?c_Media)) as ?o_image)
+        BIND(IRI(mapper:encode_iri(amsterdam:geometry\/, ?c_Trcid)) as ?o_hasGeometry)
+        (?row_index "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"") mapper:grel ?o_asWKT_grel .
+        BIND(STRDT(?o_asWKT_grel, geo:wktLiteral) as ?o_asWKT)
+        BIND(STR(?c_Adres) as ?o_Adres)
+        BIND(STR(?c_City) as ?o_City)    
+    }
+}

--- a/src/test/resources/mappings-normalizer/expected/forApplyOperations_mappings.json
+++ b/src/test/resources/mappings-normalizer/expected/forApplyOperations_mappings.json
@@ -1,0 +1,361 @@
+{
+  "op": "mapping-editor/save-rdf-mapping",
+  "mapping": {
+    "baseIRI": "http://example/base/",
+    "namespaces": {
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "schema": "http://schema.org/",
+      "geo": "http://www.opengis.net/ont/geosparql#",
+      "amsterdam": "https://data/amsterdam/nl/resource/",
+      "sf": "http://www.opengis.net/ont/sf#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+    },
+    "subjectMappings": [
+      {
+        "propertyMappings": [
+          {
+            "property": {
+              "transformation": {
+                "expression": "schema",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "title"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Title",
+                  "source": "column"
+                },
+                "valueType": {
+                  "type": "literal"
+                }
+              },
+              {
+                "valueSource": {
+                  "columnName": "TitleEN",
+                  "source": "column"
+                },
+                "valueType": {
+                  "type": "language_literal",
+                  "language": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "english"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "schema",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "description"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Shortdescription",
+                  "source": "column"
+                },
+                "valueType": {
+                  "type": "literal"
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "schema",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "latitude"
+              }
+            },
+            "values": [
+              {
+                "transformation": {
+                  "expression": "value.replace(',','.')",
+                  "language": "grel"
+                },
+                "valueSource": {
+                  "source": "row_index"
+                },
+                "valueType": {
+                  "type": "datatype_literal",
+                  "datatype": {
+                    "transformation": {
+                      "expression": "xsd",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "float"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "amsterdam",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "zipcode"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Zipcode",
+                  "source": "column"
+                },
+                "valueType": {
+                  "type": "literal"
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "schema",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "image"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Media",
+                  "source": "column"
+                },
+                "valueType": {
+                  "propertyMappings": [],
+                  "type": "iri",
+                  "typeMappings": []
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "geo",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "hasGeometry"
+              }
+            },
+            "values": [
+              {
+                "transformation": {
+                  "expression": "amsterdam:geometry/",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "columnName": "Trcid",
+                  "source": "column"
+                },
+                "valueType": {
+                  "propertyMappings": [
+                    {
+                      "property": {
+                        "transformation": {
+                          "expression": "geo",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "asWKT"
+                        }
+                      },
+                      "values": [
+                        {
+                          "transformation": {
+                            "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                            "language": "grel"
+                          },
+                          "valueSource": {
+                            "source": "row_index"
+                          },
+                          "valueType": {
+                            "type": "datatype_literal",
+                            "datatype": {
+                              "transformation": {
+                                "expression": "geo",
+                                "language": "prefix"
+                              },
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "wktLiteral"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "type": "iri",
+                  "typeMappings": [
+                    {
+                      "transformation": {
+                        "expression": "sf",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "Point"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "amsterdam",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "uniquelocation"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Trcid",
+                  "source": "column"
+                },
+                "valueType": {
+                  "propertyMappings": [
+                    {
+                      "property": {
+                        "transformation": {
+                          "expression": "amsterdam",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "address"
+                        }
+                      },
+                      "values": [
+                        {
+                          "valueSource": {
+                            "columnName": "Adres",
+                            "source": "column"
+                          },
+                          "valueType": {
+                            "type": "literal"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "type": "unique_bnode"
+                }
+              }
+            ]
+          },
+          {
+            "property": {
+              "transformation": {
+                "expression": "amsterdam",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "valuelocation"
+              }
+            },
+            "values": [
+              {
+                "valueSource": {
+                  "columnName": "Trcid",
+                  "source": "column"
+                },
+                "valueType": {
+                  "propertyMappings": [
+                    {
+                      "property": {
+                        "transformation": {
+                          "expression": "amsterdam",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "city"
+                        }
+                      },
+                      "values": [
+                        {
+                          "valueSource": {
+                            "columnName": "City",
+                            "source": "column"
+                          },
+                          "valueType": {
+                            "type": "literal"
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "type": "value_bnode"
+                }
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "transformation": {
+            "expression": "amsterdam:restaurant/",
+            "language": "prefix"
+          },
+          "valueSource": {
+            "columnName": "Trcid",
+            "source": "column"
+          }
+        },
+        "typeMappings": [
+          {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "Restaurant"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/test/resources/mappings-normalizer/expected/forRdfExport_mappings.json
+++ b/src/test/resources/mappings-normalizer/expected/forRdfExport_mappings.json
@@ -1,0 +1,358 @@
+{
+  "baseIRI": "http://example/base/",
+  "namespaces": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "schema": "http://schema.org/",
+    "geo": "http://www.opengis.net/ont/geosparql#",
+    "amsterdam": "https://data/amsterdam/nl/resource/",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+  },
+  "subjectMappings": [
+    {
+      "propertyMappings": [
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "title"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Title",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            },
+            {
+              "valueSource": {
+                "columnName": "TitleEN",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "language_literal",
+                "language": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "english"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "description"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Shortdescription",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "latitude"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "value.replace(',','.')",
+                "language": "grel"
+              },
+              "valueSource": {
+                "source": "row_index"
+              },
+              "valueType": {
+                "type": "datatype_literal",
+                "datatype": {
+                  "transformation": {
+                    "expression": "xsd",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "float"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "zipcode"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Zipcode",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "image"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Media",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [],
+                "type": "iri",
+                "typeMappings": []
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "geo",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "hasGeometry"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "amsterdam:geometry/",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "geo",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "asWKT"
+                      }
+                    },
+                    "values": [
+                      {
+                        "transformation": {
+                          "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                          "language": "grel"
+                        },
+                        "valueSource": {
+                          "source": "row_index"
+                        },
+                        "valueType": {
+                          "type": "datatype_literal",
+                          "datatype": {
+                            "transformation": {
+                              "expression": "geo",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "wktLiteral"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "iri",
+                "typeMappings": [
+                  {
+                    "transformation": {
+                      "expression": "sf",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "Point"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "uniquelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "address"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "Adres",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "unique_bnode"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "valuelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "city"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "City",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "value_bnode"
+              }
+            }
+          ]
+        }
+      ],
+      "subject": {
+        "transformation": {
+          "expression": "amsterdam:restaurant/",
+          "language": "prefix"
+        },
+        "valueSource": {
+          "columnName": "Trcid",
+          "source": "column"
+        }
+      },
+      "typeMappings": [
+        {
+          "transformation": {
+            "expression": "schema",
+            "language": "prefix"
+          },
+          "valueSource": {
+            "source": "constant",
+            "constant": "Restaurant"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mappings-normalizer/forApplyOperations_mapping.json
+++ b/src/test/resources/mappings-normalizer/forApplyOperations_mapping.json
@@ -1,0 +1,358 @@
+{
+  "baseIRI": "http://example/base/",
+  "namespaces": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "schema": "http://schema.org/",
+    "geo": "http://www.opengis.net/ont/geosparql#",
+    "amsterdam": "https://data/amsterdam/nl/resource/",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+  },
+  "subjectMappings": [
+    {
+      "propertyMappings": [
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "title"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Title",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            },
+            {
+              "valueSource": {
+                "columnName": "TitleEN",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "language_literal",
+                "language": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "english"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "description"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Shortdescription",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "latitude"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "value.replace(',','.')",
+                "language": "grel"
+              },
+              "valueSource": {
+                "source": "row_index"
+              },
+              "valueType": {
+                "type": "datatype_literal",
+                "datatype": {
+                  "transformation": {
+                    "expression": "xsd",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "float"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "zipcode"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Zipcode",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "image"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Media",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [],
+                "type": "iri",
+                "typeMappings": []
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "geo",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "hasGeometry"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "amsterdam:geometry/",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "geo",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "asWKT"
+                      }
+                    },
+                    "values": [
+                      {
+                        "transformation": {
+                          "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                          "language": "grel"
+                        },
+                        "valueSource": {
+                          "source": "row_index"
+                        },
+                        "valueType": {
+                          "type": "datatype_literal",
+                          "datatype": {
+                            "transformation": {
+                              "expression": "geo",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "wktLiteral"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "iri",
+                "typeMappings": [
+                  {
+                    "transformation": {
+                      "expression": "sf",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "Point"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "uniquelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "address"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "Adres",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "unique_bnode"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "valuelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "city"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "City",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "value_bnode"
+              }
+            }
+          ]
+        }
+      ],
+      "subject": {
+        "transformation": {
+          "expression": "amsterdam:restaurant/",
+          "language": "prefix"
+        },
+        "valueSource": {
+          "columnName": "Trcid",
+          "source": "column"
+        }
+      },
+      "typeMappings": [
+        {
+          "transformation": {
+            "expression": "schema",
+            "language": "prefix"
+          },
+          "valueSource": {
+            "source": "constant",
+            "constant": "Restaurant"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mappings-normalizer/forRdfExport_mappings.json
+++ b/src/test/resources/mappings-normalizer/forRdfExport_mappings.json
@@ -1,0 +1,358 @@
+{
+  "baseIRI": "http://example/base/",
+  "namespaces": {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "schema": "http://schema.org/",
+    "geo": "http://www.opengis.net/ont/geosparql#",
+    "amsterdam": "https://data/amsterdam/nl/resource/",
+    "sf": "http://www.opengis.net/ont/sf#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+  },
+  "subjectMappings": [
+    {
+      "propertyMappings": [
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "title"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Title",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            },
+            {
+              "valueSource": {
+                "columnName": "TitleEN",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "language_literal",
+                "language": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "english"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "description"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Shortdescription",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "latitude"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "value.replace(',','.')",
+                "language": "grel"
+              },
+              "valueSource": {
+                "source": "row_index"
+              },
+              "valueType": {
+                "type": "datatype_literal",
+                "datatype": {
+                  "transformation": {
+                    "expression": "xsd",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "float"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "zipcode"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Zipcode",
+                "source": "column"
+              },
+              "valueType": {
+                "type": "literal"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "schema",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "image"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Media",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [],
+                "type": "iri",
+                "typeMappings": []
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "geo",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "hasGeometry"
+            }
+          },
+          "values": [
+            {
+              "transformation": {
+                "expression": "amsterdam:geometry/",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "geo",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "asWKT"
+                      }
+                    },
+                    "values": [
+                      {
+                        "transformation": {
+                          "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                          "language": "grel"
+                        },
+                        "valueSource": {
+                          "source": "row_index"
+                        },
+                        "valueType": {
+                          "type": "datatype_literal",
+                          "datatype": {
+                            "transformation": {
+                              "expression": "geo",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "wktLiteral"
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "iri",
+                "typeMappings": [
+                  {
+                    "transformation": {
+                      "expression": "sf",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "Point"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "uniquelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "address"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "Adres",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "unique_bnode"
+              }
+            }
+          ]
+        },
+        {
+          "property": {
+            "transformation": {
+              "expression": "amsterdam",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "source": "constant",
+              "constant": "valuelocation"
+            }
+          },
+          "values": [
+            {
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              },
+              "valueType": {
+                "propertyMappings": [
+                  {
+                    "property": {
+                      "transformation": {
+                        "expression": "amsterdam",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "city"
+                      }
+                    },
+                    "values": [
+                      {
+                        "valueSource": {
+                          "columnName": "City",
+                          "source": "column"
+                        },
+                        "valueType": {
+                          "type": "literal"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "type": "value_bnode"
+              }
+            }
+          ]
+        }
+      ],
+      "subject": {
+        "transformation": {
+          "expression": "amsterdam:restaurant/",
+          "language": "prefix"
+        },
+        "valueSource": {
+          "columnName": "Trcid",
+          "source": "column"
+        }
+      },
+      "typeMappings": [
+        {
+          "transformation": {
+            "expression": "schema",
+            "language": "prefix"
+          },
+          "valueSource": {
+            "source": "constant",
+            "constant": "Restaurant"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/mappings-normalizer/forRdfExport_operations.json
+++ b/src/test/resources/mappings-normalizer/forRdfExport_operations.json
@@ -1,0 +1,385 @@
+{
+  "entries": [
+    {
+      "description": "Save RDF Mapping",
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example/base/",
+          "namespaces": {
+            "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            "schema": "http://schema.org/",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "amsterdam": "https://data/amsterdam/nl/resource/",
+            "sf": "http://www.opengis.net/ont/sf#",
+            "xsd": "http://www.w3.org/2001/XMLSchema#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+          },
+          "subjectMappings": [
+            {
+              "propertyMappings": [
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "schema",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Title",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    },
+                    {
+                      "valueSource": {
+                        "columnName": "TitleEN",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "type": "language_literal",
+                        "language": {
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "english"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "schema",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "description"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Shortdescription",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "schema",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "latitude"
+                    }
+                  },
+                  "values": [
+                    {
+                      "transformation": {
+                        "expression": "value.replace(',','.')",
+                        "language": "grel"
+                      },
+                      "valueSource": {
+                        "source": "row_index"
+                      },
+                      "valueType": {
+                        "type": "datatype_literal",
+                        "datatype": {
+                          "transformation": {
+                            "expression": "xsd",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "float"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "amsterdam",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "zipcode"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Zipcode",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "schema",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "image"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Media",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "propertyMappings": [],
+                        "type": "iri",
+                        "typeMappings": []
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "geo",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "hasGeometry"
+                    }
+                  },
+                  "values": [
+                    {
+                      "transformation": {
+                        "expression": "amsterdam:geometry/",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "columnName": "Trcid",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "transformation": {
+                                "expression": "geo",
+                                "language": "prefix"
+                              },
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "asWKT"
+                              }
+                            },
+                            "values": [
+                              {
+                                "transformation": {
+                                  "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                                  "language": "grel"
+                                },
+                                "valueSource": {
+                                  "source": "row_index"
+                                },
+                                "valueType": {
+                                  "type": "datatype_literal",
+                                  "datatype": {
+                                    "transformation": {
+                                      "expression": "geo",
+                                      "language": "prefix"
+                                    },
+                                    "valueSource": {
+                                      "source": "constant",
+                                      "constant": "wktLiteral"
+                                    }
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "type": "iri",
+                        "typeMappings": [
+                          {
+                            "transformation": {
+                              "expression": "sf",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "Point"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "amsterdam",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "uniquelocation"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Trcid",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "transformation": {
+                                "expression": "amsterdam",
+                                "language": "prefix"
+                              },
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "address"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "columnName": "Adres",
+                                  "source": "column"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "type": "unique_bnode"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "property": {
+                    "transformation": {
+                      "expression": "amsterdam",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "valuelocation"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "columnName": "Trcid",
+                        "source": "column"
+                      },
+                      "valueType": {
+                        "propertyMappings": [
+                          {
+                            "property": {
+                              "transformation": {
+                                "expression": "amsterdam",
+                                "language": "prefix"
+                              },
+                              "valueSource": {
+                                "source": "constant",
+                                "constant": "city"
+                              }
+                            },
+                            "values": [
+                              {
+                                "valueSource": {
+                                  "columnName": "City",
+                                  "source": "column"
+                                },
+                                "valueType": {
+                                  "type": "literal"
+                                }
+                              }
+                            ]
+                          }
+                        ],
+                        "type": "value_bnode"
+                      }
+                    }
+                  ]
+                }
+              ],
+              "subject": {
+                "transformation": {
+                  "expression": "amsterdam:restaurant/",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "columnName": "Trcid",
+                  "source": "column"
+                }
+              },
+              "typeMappings": [
+                {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "Restaurant"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      }
+    },
+    {
+      "description": "Text transform on 725 cells in column City: value.toTitlecase()",
+      "operation": {
+        "op": "core/text-transform",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "columnName": "City",
+        "expression": "value.toTitlecase()",
+        "onError": "keep-original",
+        "repeat": false,
+        "repeatCount": 10,
+        "description": "Text transform on cells in column City using expression value.toTitlecase()"
+      }
+    }
+  ]
+}

--- a/src/test/resources/mappings-normalizer/forRdfExport_project-models.json
+++ b/src/test/resources/mappings-normalizer/forRdfExport_project-models.json
@@ -1,0 +1,658 @@
+{
+  "columnModel": {
+    "columns": [
+      {
+        "cellIndex": 0,
+        "originalName": "Trcid",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Trcid"
+      },
+      {
+        "cellIndex": 1,
+        "originalName": "Title",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Title"
+      },
+      {
+        "cellIndex": 2,
+        "originalName": "Shortdescription",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Shortdescription"
+      },
+      {
+        "cellIndex": 3,
+        "originalName": "Longdescription",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Longdescription"
+      },
+      {
+        "cellIndex": 4,
+        "originalName": "Calendarsummary",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Calendarsummary"
+      },
+      {
+        "cellIndex": 5,
+        "originalName": "TitleEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "TitleEN"
+      },
+      {
+        "cellIndex": 6,
+        "originalName": "ShortdescriptionEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "ShortdescriptionEN"
+      },
+      {
+        "cellIndex": 7,
+        "originalName": "LongdescriptionEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "LongdescriptionEN"
+      },
+      {
+        "cellIndex": 8,
+        "originalName": "CalendarsummaryEN",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "CalendarsummaryEN"
+      },
+      {
+        "cellIndex": 9,
+        "originalName": "Types",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Types"
+      },
+      {
+        "cellIndex": 10,
+        "originalName": "Ids",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Ids"
+      },
+      {
+        "cellIndex": 11,
+        "originalName": "Locatienaam",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Locatienaam"
+      },
+      {
+        "cellIndex": 12,
+        "originalName": "City",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "City"
+      },
+      {
+        "cellIndex": 13,
+        "originalName": "Adres",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Adres"
+      },
+      {
+        "cellIndex": 14,
+        "originalName": "Zipcode",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Zipcode"
+      },
+      {
+        "cellIndex": 15,
+        "originalName": "Latitude",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Latitude"
+      },
+      {
+        "cellIndex": 16,
+        "originalName": "Longitude",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Longitude"
+      },
+      {
+        "cellIndex": 17,
+        "originalName": "Urls",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Urls"
+      },
+      {
+        "cellIndex": 18,
+        "originalName": "Media",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Media"
+      },
+      {
+        "cellIndex": 19,
+        "originalName": "Thumbnail",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Thumbnail"
+      },
+      {
+        "cellIndex": 20,
+        "originalName": "Datepattern_startdate",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Datepattern_startdate"
+      },
+      {
+        "cellIndex": 21,
+        "originalName": "Datepattern_enddate",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Datepattern_enddate"
+      },
+      {
+        "cellIndex": 22,
+        "originalName": "Singledates",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Singledates"
+      },
+      {
+        "cellIndex": 23,
+        "originalName": "Type1",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Type1"
+      },
+      {
+        "cellIndex": 24,
+        "originalName": "Lastupdated",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Lastupdated"
+      },
+      {
+        "cellIndex": 25,
+        "originalName": "Column",
+        "constraints": "{}",
+        "type": "",
+        "format": "default",
+        "title": "",
+        "description": "",
+        "name": "Column"
+      }
+    ],
+    "columnGroups": [],
+    "keyCellIndex": 0,
+    "keyColumnName": "Trcid"
+  },
+  "recordModel": {
+    "hasRecords": false
+  },
+  "overlayModels": {
+    "mappingDefinition": {
+      "mappingDefinition": {
+        "baseIRI": "http://example/base/",
+        "namespaces": {
+          "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          "schema": "http://schema.org/",
+          "geo": "http://www.opengis.net/ont/geosparql#",
+          "amsterdam": "https://data/amsterdam/nl/resource/",
+          "sf": "http://www.opengis.net/ont/sf#",
+          "xsd": "http://www.w3.org/2001/XMLSchema#",
+          "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "subjectMappings": [
+          {
+            "propertyMappings": [
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Title",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  },
+                  {
+                    "valueSource": {
+                      "columnName": "TitleEN",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "language_literal",
+                      "language": {
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "english"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "description"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Shortdescription",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "latitude"
+                  }
+                },
+                "values": [
+                  {
+                    "transformation": {
+                      "expression": "value.replace(',','.')",
+                      "language": "grel"
+                    },
+                    "valueSource": {
+                      "source": "row_index"
+                    },
+                    "valueType": {
+                      "type": "datatype_literal",
+                      "datatype": {
+                        "transformation": {
+                          "expression": "xsd",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "float"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "zipcode"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Zipcode",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "image"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Media",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [],
+                      "type": "iri",
+                      "typeMappings": []
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "geo",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "hasGeometry"
+                  }
+                },
+                "values": [
+                  {
+                    "transformation": {
+                      "expression": "amsterdam:geometry/",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "geo",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "asWKT"
+                            }
+                          },
+                          "values": [
+                            {
+                              "transformation": {
+                                "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                                "language": "grel"
+                              },
+                              "valueSource": {
+                                "source": "row_index"
+                              },
+                              "valueType": {
+                                "type": "datatype_literal",
+                                "datatype": {
+                                  "transformation": {
+                                    "expression": "geo",
+                                    "language": "prefix"
+                                  },
+                                  "valueSource": {
+                                    "source": "constant",
+                                    "constant": "wktLiteral"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "iri",
+                      "typeMappings": [
+                        {
+                          "transformation": {
+                            "expression": "sf",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "Point"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "uniquelocation"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "amsterdam",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "address"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "columnName": "Adres",
+                                "source": "column"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "unique_bnode"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "valuelocation"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "amsterdam",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "city"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "columnName": "City",
+                                "source": "column"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "value_bnode"
+                    }
+                  }
+                ]
+              }
+            ],
+            "subject": {
+              "transformation": {
+                "expression": "amsterdam:restaurant/",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              }
+            },
+            "typeMappings": [
+              {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "Restaurant"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "scripting": {
+    "grel": {
+      "name": "General Refine Expression Language (GREL)",
+      "defaultExpression": "value"
+    },
+    "clojure": {
+      "name": "Clojure",
+      "defaultExpression": "value"
+    }
+  },
+  "httpHeaders": {
+    "authorization": {
+      "header": "Authorization",
+      "defaultValue": ""
+    },
+    "user-agent": {
+      "header": "User-Agent",
+      "defaultValue": "OpenRefine 2.6 [1]"
+    },
+    "accept": {
+      "header": "Accept",
+      "defaultValue": "*/*"
+    }
+  }
+}


### PR DESCRIPTION
Introduces additional mechanism for RDF data export

- Added new command for RDF data export, which uses SPARQL CONSTRUCT
query and the GraphDB REST API to convert given data in RDF format.
- Added mechanism for execution of integration test over secured GraphDB
instance.
- Renamed `ExportRdfCommand` to `DefaultExportRdfCommand`.
- Updated the version of the GraphDB instance used for integration tests
from `9.10.0` to `10.0.0` in order to take advantage of the
functionalities, which aren't requiring license in order to be used.
- Added test utility for comparison of RDF data, which is not affected
by the generation of the BNodes IRIs.

---
Adds support for safe RDF mapping usage in commands

- Added logic which allows usage of the RDF mapping JSON in formats for
the commands. The logic will detect and correct the format of the RDF
mapping, depending on the command that is currently executed.

This is more of a usability issue related to the extraction of the
mapping JSON from different places, when the user uses the OR and
mapping user interfaces.

---
Prepares the library for the release 1.5.0

- Removed the `SNAPSHOT` suffix from the pom version.
- Updated the README dependency example to the latest release.