### PR TITLE
Fixes issue with the encoding of the query used for SPARQL RDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 ### Bug fixes
 
 
+## Version 1.6.1
+
+### Bug fixes
+
+ - Changed the mechanism of encoding for the content of the entity, which represents the SPARQL conversion query. Apparently there are characters that are not handled
+   correctly by the ``java.net.URLEncoder``. Now we are going to just use ``UrlEncodedFormEntity``, which handles the encoding in correct way.
+
+
 ## Version 1.6
 
 ### New

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ complete given operation.
  <dependency>
      <groupId>com.ontotext</groupId>
      <artifactId>ontorefine-client</artifactId>
-     <version>1.6.0</version>
+     <version>1.6.1</version>
  </dependency>
 ```
 


### PR DESCRIPTION
- Changed the mechanism of encoding of the content for the HTTP entity
used for payload of the request for the RDF export.
- Added logging of the SPARQL which will be executed for the RDF export.