### PR TITLE
Introduces changes in the RDF export result storing and retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@
 ### Bug fixes
 
 
+## Version 1.6.3
+
+### Changes
+
+ - Changed the logic related to the RDF export return type introduced in ``1.6.2``. Now the output type is moved as property of the command, instead of sub-property of
+   the ``ResultFormat``. This way the setting of the options is more transparent and explicit for the user.
+ - Changed the handling of the different result return types from the ``ExportRdfResponse``. Now the result can be retrieved by each of the methods which is more
+   convenient for the usage. The actual result is converted from either from the in-memory buffered ``String`` or temporary file.
+   **Note**: when retrieving the result as ``String``, but it exceeds the buffer size, OOM will be thrown by underlining library used for the conversion. In such cases,
+   it is recommended to work with the file based result.
+
+
 ## Version 1.6.2
 
 ### New

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ complete given operation.
  <dependency>
      <groupId>com.ontotext</groupId>
      <artifactId>ontorefine-client</artifactId>
-     <version>1.6.2</version>
+     <version>1.6.3</version>
  </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/Ontotext-AD/ontorefine-client.git</connection>
-        <developerConnection>scm:git:https://github.com/Ontotext-AD/ontorefine-client.git</developerConnection>
+        <connection>scm:git:git@github.com/Ontotext-AD/ontorefine-client.git</connection>
+        <developerConnection>scm:git:git@github.com/Ontotext-AD/ontorefine-client.git</developerConnection>
         <url>https://github.com/Ontotext-AD/ontorefine-client</url>
     </scm>
 

--- a/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/DefaultExportRdfCommand.java
@@ -31,11 +31,14 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
   private final String project;
   private final String mapping;
   private final ResultFormat format;
+  private final OutputType output;
 
-  private DefaultExportRdfCommand(String project, String mapping, ResultFormat format) {
+  private DefaultExportRdfCommand(
+      String project, String mapping, ResultFormat format, OutputType output) {
     this.project = project;
     this.mapping = mapping;
     this.format = format;
+    this.output = output;
   }
 
   @Override
@@ -72,7 +75,7 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
 
   @Override
   public ExportRdfResponse handleResponse(HttpResponse response) throws IOException {
-    return RdfExportResponseHandler.handle(project, format, response);
+    return RdfExportResponseHandler.handle(project, response, output);
   }
 
   /**
@@ -85,6 +88,7 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
     private String project;
     private String mapping;
     private ResultFormat format;
+    private OutputType output;
 
     public Builder setProject(String project) {
       this.project = project;
@@ -101,6 +105,11 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
       return this;
     }
 
+    public Builder setOutput(OutputType output) {
+      this.output = output;
+      return this;
+    }
+
     /**
      * Builds a {@link DefaultExportRdfCommand}.
      *
@@ -110,7 +119,7 @@ public class DefaultExportRdfCommand implements RefineCommand<ExportRdfResponse>
       notBlank(project, "Missing 'project' argument");
       notBlank(mapping, "Missing 'mapping' argument");
       notNull(format, "Missing 'format' argument");
-      return new DefaultExportRdfCommand(project, mapping, format);
+      return new DefaultExportRdfCommand(project, mapping, format, output);
     }
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
@@ -1,7 +1,14 @@
 package com.ontotext.refine.client.command.rdf;
 
+import static com.ontotext.refine.client.command.rdf.RdfExportFileUtils.createTempFile;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Holds the result from export RDF commands.
@@ -12,7 +19,6 @@ public class ExportRdfResponse {
 
   private String project;
   private String result;
-  private InputStream resultStream;
   private File resultFile;
 
   public String getProject() {
@@ -24,8 +30,8 @@ public class ExportRdfResponse {
     return this;
   }
 
-  public String getResult() {
-    return result;
+  public String getResult() throws IOException {
+    return resultFile == null ? result : Files.readString(resultFile.toPath());
   }
 
   ExportRdfResponse setResult(String result) {
@@ -33,16 +39,29 @@ public class ExportRdfResponse {
     return this;
   }
 
-  public InputStream getResultStream() {
-    return resultStream;
+  /**
+   * Retrieves the result as stream. The result is returned either as {@link ByteArrayInputStream}
+   * or {@link FileInputStream} depending on whether it was buffered in-memory or written in a file.
+   *
+   * @return stream of the result
+   * @throws IOException when error occurs during the result streaming
+   */
+  public InputStream getResultStream() throws IOException {
+    return resultFile == null
+        ? new ByteArrayInputStream(result.getBytes())
+        : new FileInputStream(resultFile);
   }
 
-  ExportRdfResponse setResultStream(InputStream resultStream) {
-    this.resultStream = resultStream;
-    return this;
-  }
-
-  public File getResultFile() {
+  /**
+   * Retrieves the result as file.
+   *
+   * @return file containing the result from the RDF export
+   * @throws IOException when error occurs during file IO operations
+   */
+  public File getResultFile() throws IOException {
+    if (resultFile == null && StringUtils.isNotBlank(result)) {
+      resultFile = Files.write(createTempFile(project), result.getBytes()).toFile();
+    }
     return resultFile;
   }
 

--- a/src/main/java/com/ontotext/refine/client/command/rdf/OutputType.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/OutputType.java
@@ -1,0 +1,10 @@
+package com.ontotext.refine.client.command.rdf;
+
+/**
+ * Provides the available types for the result output.
+ *
+ * @author Antoniy Kunchev
+ */
+enum OutputType {
+  STRING, FILE
+}

--- a/src/main/java/com/ontotext/refine/client/command/rdf/RdfExportFileUtils.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/RdfExportFileUtils.java
@@ -1,0 +1,33 @@
+package com.ontotext.refine.client.command.rdf;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Contains convenient methods for files processing during RDF export.
+ *
+ * @author Antoniy Kunchev
+ */
+class RdfExportFileUtils {
+
+  private RdfExportFileUtils() {
+    throw new UnsupportedOperationException("Utility class.");
+  }
+
+  /**
+   * Creates temporary file with name pattern:<br>
+   * <i>project-{project identifier}-rdfExport-{java generated number}.tmp</i><br>
+   * in temporary directory prefixed with: <br>
+   * <i>ontorefine-client-{java generated number}</i>.
+   *
+   * @param project the identifer of the refine project, which data is exported
+   * @return path to the created file
+   * @throws IOException when there is an error during the file creation
+   */
+  static Path createTempFile(String project) throws IOException {
+    Path tempDirectory = Files.createTempDirectory("ontorefine-client-");
+    String suffix = "project-" + project + "-rdfExport-";
+    return Files.createTempFile(tempDirectory, suffix, ".tmp");
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ResultFormat.java
@@ -39,38 +39,12 @@ public enum ResultFormat {
   HDT(RDFFormat.HDT);
 
   private final RDFFormat rdfFormat;
-  private ResultType as;
 
   private ResultFormat(RDFFormat format) {
     this.rdfFormat = format;
-    this.as = ResultType.STRING;
   }
 
   public RDFFormat getRdfFormat() {
     return rdfFormat;
-  }
-
-  /**
-   * Sets the expected result type.
-   *
-   * @param as the type of the result
-   * @return current {@link ResultFormat} object
-   */
-  public ResultFormat as(ResultType as) {
-    this.as = as;
-    return this;
-  }
-
-  public ResultType getAs() {
-    return as;
-  }
-
-  /**
-   * Provides options for type of the result in which the exported data can be returned.
-   *
-   * @author Antoniy Kunchev
-   */
-  public enum ResultType {
-    STRING, FILE, STREAM
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedExportRdfCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedExportRdfCommand.java
@@ -44,18 +44,21 @@ public class SparqlBasedExportRdfCommand implements RefineCommand<ExportRdfRespo
   private final String query;
   private final ResultFormat format;
   private final String repository;
+  private final OutputType output;
 
   private SparqlBasedExportRdfCommand(
       String project,
       String projectPlaceholder,
       String query,
       ResultFormat format,
-      String repository) {
+      String repository,
+      OutputType output) {
     this.project = project;
     this.projectPlaceholder = projectPlaceholder;
     this.query = query;
     this.format = format;
     this.repository = repository;
+    this.output = output;
   }
 
   @Override
@@ -114,7 +117,7 @@ public class SparqlBasedExportRdfCommand implements RefineCommand<ExportRdfRespo
 
   @Override
   public ExportRdfResponse handleResponse(HttpResponse response) throws IOException {
-    return RdfExportResponseHandler.handle(project, format, response);
+    return RdfExportResponseHandler.handle(project, response, output);
   }
 
   /**
@@ -129,6 +132,7 @@ public class SparqlBasedExportRdfCommand implements RefineCommand<ExportRdfRespo
     private String query;
     private ResultFormat format;
     private String repository;
+    private OutputType output;
 
     public Builder setProject(String project) {
       this.project = project;
@@ -167,7 +171,7 @@ public class SparqlBasedExportRdfCommand implements RefineCommand<ExportRdfRespo
       notNull(format, "Missing 'format' argument");
       notBlank(repository, "Missing 'repository' argument");
       return new SparqlBasedExportRdfCommand(
-          project, projectPlaceholder, query, format, repository);
+          project, projectPlaceholder, query, format, repository, output);
     }
   }
 }

--- a/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.ontotext.refine.client.RefineClient;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.net.URI;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
@@ -71,9 +72,21 @@ public abstract class BaseCommandTest<T, R extends RefineCommand<T>> {
    * @return HTTP response instance
    */
   protected HttpResponse okResponse(InputStream body) {
+    return okResponse(body, BigInteger.valueOf(-1));
+  }
+
+  /**
+   * Creates response with status 'OK'.
+   *
+   * @param body for the response
+   * @param contentLength used to explicitly set the length of the content
+   * @return HTTP response instance
+   */
+  protected HttpResponse okResponse(InputStream body, BigInteger contentLength) {
     BasicStatusLine statusLine = new BasicStatusLine(HttpVersion.HTTP_1_1, 200, "OK");
     BasicHttpEntity entity = new BasicHttpEntity();
     entity.setContent(body);
+    entity.setContentLength(contentLength.longValue());
     BasicHttpResponse response = new BasicHttpResponse(statusLine);
     response.setEntity(entity);
     return response;


### PR DESCRIPTION
- Changed the storing and the retrieval mechanisms for the RDF export
result. Now the buffering of the result will depend on the length of the
content of the return HTTP entity and/or if the user explicitly requests
the result in specific type.

The options for the return type were reduced and move as command
property, instead of sub-property of the ``ResultFormat``. This makes
the configuration more transparent and simple to use.

Additionally, now the result of the export can be retrieved from all
available methods in the response, which is more continent in specific
cases.
Exception to that is the case, where the result is stored in a file and
the content exceeds the ``String`` buffer size. When such case occurs
and the user retrieves the result as ``String``, OOM will be thrown.