### PR TITLE
Updates the dependencies and CI pipelines of the project

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Cache SonarCloud packages
       uses: actions/cache@v3

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         server-id: all-onto # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: ONTO_MVN_USER_REF
         server-password: ONTO_MVN_TOKEN_REF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Changes
 
+ - Updates the version of all third party dependencies used by the project. This is done in order to keep the project up-to-date and avoid potential security issues due
+   vulnerabilities in the libraries.
+ - Updated the CI and release workflow configurations to use `temurin` Java distribution instead of `adopt`. The main reason for this change is the fact that `adopt`
+   actually moved to `temurin` and it won't be supported anymore.
+
 ### Bug fixes
 
 
@@ -36,7 +41,7 @@
 
  - All stream IO operations are now done in ``UTF-8``. There are some utility libraries that have different default charset. To keep the library consistent and
    the behavior predictable, we explicitly set the charset to ``UTF-8``.
- - All third party and utility libraries are not updated to the latest version. There were issues with the artifact deployment so in order to solve it some of the
+ - All third party and utility libraries are now updated to the latest version. There were issues with the artifact deployment so in order to solve it some of the
    libraries had to be updated, but in the process we ended up updating all.
  - Updated the versions of the actions used in the CI and Release processes.
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <version>1.7.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
-    <description>An OntoRefine Client Library</description>
+    <description>An Ontotext Refine Client Library</description>
     <url>https://github.com/Ontotext-AD/ontorefine-client</url>
 
     <licenses>
@@ -23,7 +23,7 @@
     <developers>
         <developer>
             <name>The Ontotext Team</name>
-            <email><!-- TODO --></email>
+            <email>refine-support@ontotext.com</email>
             <organization>Ontotext-AD</organization>
             <organizationUrl>https://github.com/Ontotext-AD</organizationUrl>
         </developer>
@@ -57,21 +57,21 @@
         <sonar.coverage.jacoco.xmlReportPaths>../ontorefine-client/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
-        <maven.resources.plugin.version>3.2.0</maven.resources.plugin.version>
+        <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
-        <maven.surefire.plugin.version>3.0.0-M6</maven.surefire.plugin.version>
-        <dependency.check.plugin.version>7.1.0</dependency.check.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
+        <dependency.check.plugin.version>7.1.1</dependency.check.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
 
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.io.version>2.11.0</commons.io.version>
-        <jackson.databind.version>2.13.2.2</jackson.databind.version>
-        <rdf4j.version>4.0.0</rdf4j.version>
+        <jackson.databind.version>2.13.3</jackson.databind.version>
+        <rdf4j.version>4.1.0</rdf4j.version>
 
-        <junit.jupiter.version>5.8.2</junit.jupiter.version>
-        <mockito.version>4.5.1</mockito.version>
-        <testcontainers.version>1.17.1</testcontainers.version>
+        <junit.jupiter.version>5.9.0</junit.jupiter.version>
+        <mockito.version>4.6.1</mockito.version>
+        <testcontainers.version>1.17.3</testcontainers.version>
         <e2e.graphdb.docker.image>ontotext/graphdb:10.0.0-M1</e2e.graphdb.docker.image>
 
         <checkstyle.enabled>true</checkstyle.enabled>

--- a/src/main/java/com/ontotext/refine/client/RefineClients.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClients.java
@@ -25,7 +25,7 @@ public interface RefineClients {
    * @return new default {@link RefineClient} instance
    * @throws URISyntaxException when the input <code>uri</code> argument is invalid
    */
-  @Deprecated
+  @Deprecated(since = "1.4", forRemoval = true)
   static RefineClient create(String uri) throws URISyntaxException {
     return standard(uri);
   }


### PR DESCRIPTION
- Updated the CI and release pipelines to use Java `temurin`
distribution, instead of `adopt`. The reason for this change is that
`adopt` moved to `temurin` and it no longer will be supported.
- Updated the third party dependencies that are used in the project to
the latest version. This is done in order to keep the project up-to-data
and avoid potential security issues.