### PR TITLE
Introduces new command for RDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,30 @@
 
 ### New
 
+ - Added new profile `local` for Maven builds which disables the dependency and checkstyle checks. This profile is used for quick local build that is to be used for
+   testing.
+ - Introduced new command for RDF export, which uses Ontotext Refine to generate the RDF, instead GraphDB. The command uses SPARQL CONSTRUCT query to map the tabular
+   project data to RDF. The command uses the SAPRQL endpoint exposed by Ontotext Refine allowing execution of query over the data of specific refine project.
+ - `MappingsNormalizer` now handles additional case, where the mappings JSON is passes as array of operations.
+ 
+### Breaking Changes
+
+ - The current version introduces some breaking changes related to the separation of the GraphDB and Ontotext Refine. The command for RDF export, now named
+   `GraphDbSparqlBasedRdfExportCommand` will not work with GraphDB 9 anymore. The command will be kept as it is still relevant and it can be adjusted to work with
+   GraphDB instance for more flexibility in the future. Currently there is a workaround allowing the command to work with the the first version of the Ontotext Refine.
+
 ### Changes
 
  - Updates the version of all third party dependencies used by the project. This is done in order to keep the project up-to-date and avoid potential security issues due
    vulnerabilities in the libraries.
  - Updated the CI and release workflow configurations to use `temurin` Java distribution instead of `adopt`. The main reason for this change is the fact that `adopt`
    actually moved to `temurin` and it won't be supported anymore.
+ - Minor refactoring and renaming for some of the command classes.
 
 ### Bug fixes
+
+ - Updated the retrival of the content length, when deciding whether to store the RDF export result in the memory or a file. Now instead of only relying on the entity
+   content length property, the logic will try to extract the length from the response header.
 
 
 ## Version 1.6.3

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <e2e.graphdb.docker.image>ontotext/graphdb:10.0.0-M1</e2e.graphdb.docker.image>
 
         <checkstyle.enabled>true</checkstyle.enabled>
+        <skip.dependency.check>false</skip.dependency.check>
     </properties>
 
     <profiles>
@@ -82,6 +83,13 @@
             <id>develop</id>
             <properties>
                 <checkstyle.enabled>false</checkstyle.enabled>
+            </properties>
+        </profile>
+        <profile>
+            <id>local</id>
+            <properties>
+                <checkstyle.enabled>false</checkstyle.enabled>
+                <skip.dependency.check>true</skip.dependency.check>
             </properties>
         </profile>
     </profiles>
@@ -246,6 +254,7 @@
                 <artifactId>dependency-check-maven</artifactId>
                 <version>${dependency.check.plugin.version}</version>
                 <configuration>
+                    <skip>${skip.dependency.check}</skip>
                     <failBuildOnCVSS>${cvss.threshold}</failBuildOnCVSS>
                 </configuration>
                 <executions>

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
@@ -10,8 +10,9 @@ import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.command.preferences.GetPreferenceCommand;
 import com.ontotext.refine.client.command.preferences.SetPreferenceCommand;
 import com.ontotext.refine.client.command.processes.GetProcessesCommand;
-import com.ontotext.refine.client.command.rdf.DefaultExportRdfCommand;
-import com.ontotext.refine.client.command.rdf.SparqlBasedExportRdfCommand;
+import com.ontotext.refine.client.command.rdf.DefaultRdfExportCommand;
+import com.ontotext.refine.client.command.rdf.GraphDbSparqlBasedRdfExportCommand;
+import com.ontotext.refine.client.command.rdf.SparqlBasedRdfExportCommand;
 import com.ontotext.refine.client.command.reconcile.GuessColumnTypeCommand;
 import com.ontotext.refine.client.command.reconcile.ReconServiceRegistrationCommand;
 import com.ontotext.refine.client.command.reconcile.ReconcileCommand;
@@ -104,21 +105,33 @@ public interface RefineCommands {
   }
 
   /**
-   * Provides a builder instance for the {@link DefaultExportRdfCommand}.
+   * Provides a builder instance for the {@link DefaultRdfExportCommand}.
    *
    * @return new builder instance
    */
-  static DefaultExportRdfCommand.Builder exportRdf() {
-    return new DefaultExportRdfCommand.Builder();
+  static DefaultRdfExportCommand.Builder exportRdf() {
+    return new DefaultRdfExportCommand.Builder();
   }
 
   /**
-   * Provides a builder instance for the {@link SparqlBasedExportRdfCommand}.
+   * Provides a builder instance for the {@link SparqlBasedRdfExportCommand}.
    *
    * @return new builder instance
    */
-  static SparqlBasedExportRdfCommand.Builder exportRdfUsingSparql() {
-    return new SparqlBasedExportRdfCommand.Builder();
+  static SparqlBasedRdfExportCommand.Builder exportAsRdf() {
+    return new SparqlBasedRdfExportCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link GraphDbSparqlBasedRdfExportCommand}.
+   *
+   * <p>CAUSION! The command may not work, because of the separation of the GraphDB and Ontotext
+   * Refine tool. The logic is out-of-date, regardless of the fix that is implemented at the moment.
+   *
+   * @return new builder instance
+   */
+  static GraphDbSparqlBasedRdfExportCommand.Builder exportRdfUsingSparql() {
+    return new GraphDbSparqlBasedRdfExportCommand.Builder();
   }
 
   /**

--- a/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/ExportRdfResponse.java
@@ -1,6 +1,6 @@
 package com.ontotext.refine.client.command.rdf;
 
-import static com.ontotext.refine.client.command.rdf.RdfExportFileUtils.createTempFile;
+import static com.ontotext.refine.client.command.rdf.RdfExportUtils.createTempFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/src/main/java/com/ontotext/refine/client/command/rdf/RdfExportUtils.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/RdfExportUtils.java
@@ -3,15 +3,16 @@ package com.ontotext.refine.client.command.rdf;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
- * Contains convenient methods for files processing during RDF export.
+ * Contains convenient methods used in RDF export commands.
  *
  * @author Antoniy Kunchev
  */
-class RdfExportFileUtils {
+class RdfExportUtils {
 
-  private RdfExportFileUtils() {
+  private RdfExportUtils() {
     throw new UnsupportedOperationException("Utility class.");
   }
 
@@ -29,5 +30,16 @@ class RdfExportFileUtils {
     Path tempDirectory = Files.createTempDirectory("ontorefine-client-");
     String suffix = "project-" + project + "-rdfExport-";
     return Files.createTempFile(tempDirectory, suffix, ".tmp");
+  }
+
+  /**
+   * Provides value for accept header derived from the input format.
+   *
+   * @param format to be used to build the header value
+   * @return string representation of the header value
+   */
+  static String getAcceptHeader(ResultFormat format) {
+    RDFFormat rdfFormat = format.getRdfFormat();
+    return rdfFormat.getDefaultMIMEType() + ";charset=" + rdfFormat.getCharset();
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedRdfExportCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/rdf/SparqlBasedRdfExportCommand.java
@@ -1,0 +1,155 @@
+package com.ontotext.refine.client.command.rdf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.Validate.notBlank;
+import static org.apache.commons.lang3.Validate.notNull;
+import static org.apache.http.HttpHeaders.ACCEPT;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A command that exports the data of specific project in RDF format using a SPARQL Construct query.
+ * The command uses the SPARQL endpoint that Ontotext Refine tool provides, thus avoiding the
+ * dependency to the GraphDB. <br>
+ * Additionally the query doesn't need to be a template and contain <code>SERVICE</code> clause for
+ * federation, it can be simple <code>CONSTRUCT</code> query.<br>
+ * Example:
+ *
+ * <pre>
+ * BASE &lt;http://example.com/base/&gt;
+ *
+ * CONSTRUCT {
+ *   ?subject &lt;title&gt; ?o_title .
+ * } WHERE {
+ *   BIND(&lt;subject&gt; as ?subject)
+ *   BIND(STR(?c_Title) as ?o_title)
+ * }
+ * </pre>
+ *
+ * @author Antoniy Kunchev
+ */
+public class SparqlBasedRdfExportCommand implements RefineCommand<ExportRdfResponse> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparqlBasedRdfExportCommand.class);
+
+  private static final String SPARQL_QUERY_CONTENT_TYPE = "application/sparql-query";
+  private static final String ONTOREFINE_PREFIX = "ontorefine:";
+
+  private final String project;
+  private final String prefix;
+  private final String query;
+  private final ResultFormat format;
+  private final OutputType output;
+
+  private SparqlBasedRdfExportCommand(
+      String project, String prefix, String query, ResultFormat format, OutputType output) {
+    this.project = project;
+    this.prefix = prefix;
+    this.query = query;
+    this.format = format;
+    this.output = output;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/repositories/";
+  }
+
+  @Override
+  public ExportRdfResponse execute(RefineClient client) throws RefineException {
+    try {
+      String pfx = StringUtils.defaultIfBlank(prefix, ONTOREFINE_PREFIX);
+      HttpUriRequest request = RequestBuilder
+          .post(client.createUri(endpoint() + pfx + project))
+          .addHeader(ACCEPT, RdfExportUtils.getAcceptHeader(format))
+          .addHeader(CONTENT_TYPE, SPARQL_QUERY_CONTENT_TYPE)
+          .setEntity(buildEntity())
+          .build();
+
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      throw new RefineException(
+          "Export of RDF data failed for project: '%s' due to: %s",
+          project,
+          ioe.getMessage());
+    }
+  }
+
+  /**
+   * Builds the request entity with the expected content. The produced {@link HttpEntity} is
+   * repeatable so that it can be used in retries.
+   */
+  private HttpEntity buildEntity() throws IOException {
+    LOGGER.debug("The query that will be used for RDF export is: {}", query);
+    return new BufferedHttpEntity(new StringEntity(query, UTF_8));
+  }
+
+  @Override
+  public ExportRdfResponse handleResponse(HttpResponse response) throws IOException {
+    return RdfExportResponseHandler.handle(project, response, output);
+  }
+
+  /**
+   * Builder for the {@link SparqlBasedRdfExportCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String project;
+    private String prefix;
+    private String query;
+    private ResultFormat format;
+    private OutputType output;
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setPrefix(String prefix) {
+      this.prefix = prefix;
+      return this;
+    }
+
+    public Builder setQuery(String query) {
+      this.query = query;
+      return this;
+    }
+
+    public Builder setFormat(ResultFormat format) {
+      this.format = format;
+      return this;
+    }
+
+    public Builder setOutput(OutputType output) {
+      this.output = output;
+      return this;
+    }
+
+    /**
+     * Builds new {@link SparqlBasedRdfExportCommand}.
+     *
+     * @return new command
+     */
+    public SparqlBasedRdfExportCommand build() {
+      notBlank(project, "Missing 'project' argument");
+      notBlank(query, "Missing 'query' argument");
+      notNull(format, "Missing 'format' argument");
+      return new SparqlBasedRdfExportCommand(project, prefix, query, format, output);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/util/mappings/MappingsNormalizer.java
+++ b/src/main/java/com/ontotext/refine/client/util/mappings/MappingsNormalizer.java
@@ -9,7 +9,9 @@ import com.ontotext.refine.client.command.operations.ApplyOperationsCommand;
 import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.exceptions.RefineException;
 import com.ontotext.refine.client.util.mappings.MappingsStructures.MappingJson;
+import com.ontotext.refine.client.util.mappings.MappingsStructures.OperationEntry;
 import com.ontotext.refine.client.util.mappings.MappingsStructures.OperationsJson;
+import com.ontotext.refine.client.util.mappings.MappingsStructures.RelaxedOperationEntry;
 import java.util.List;
 import java.util.function.Predicate;
 import org.apache.commons.lang3.StringUtils;
@@ -50,10 +52,21 @@ public class MappingsNormalizer {
       return extractMappingsFromOperations(json);
     }
 
+    // operations array JSON case
+    if (JSON_PARSER.isAssignable(json, OperationEntry[].class)) {
+      return extractMappingsFromOperations(json);
+    }
+
     // project models case
     String mappingsStr = tryExtractFromModels(json);
     if (mappingsStr != null) {
       return mappingsStr;
+    }
+
+    // last resort
+    // operations array JSON case
+    if (JSON_PARSER.isAssignable(json, RelaxedOperationEntry[].class)) {
+      return extractMappingsFromOperations(json);
     }
 
     return null;

--- a/src/main/java/com/ontotext/refine/client/util/mappings/MappingsStructures.java
+++ b/src/main/java/com/ontotext/refine/client/util/mappings/MappingsStructures.java
@@ -1,5 +1,7 @@
 package com.ontotext.refine.client.util.mappings;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +47,19 @@ final class MappingsStructures {
     private String description;
 
     @JsonProperty
+    @JsonAlias({"op", "operation"})
     private Object operation;
+  }
+
+  /**
+   * Relaxed structure for materializing the single operation from operations JSON. It will ignore
+   * any unknown property.
+   *
+   * @author Antoniy Kunchev
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class RelaxedOperationEntry extends OperationEntry {
+    // nothing more
   }
 
   /**

--- a/src/test/java/com/ontotext/refine/client/IntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/IntegrationTest.java
@@ -129,7 +129,7 @@ public abstract class IntegrationTest {
         HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
         BasicCredentialsProvider provider = new BasicCredentialsProvider();
         provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("admin", "root"));
-        return RefineClients.securityAware(httpHost.toURI(), provider);
+        securedRefineClient = RefineClients.securityAware(httpHost.toURI(), provider);
       } catch (URISyntaxException uriExc) {
         throw new RuntimeException("Failed to create secured refine client.", uriExc);
       }
@@ -141,7 +141,7 @@ public abstract class IntegrationTest {
     if (refineClient == null) {
       try {
         HttpHost httpHost = new HttpHost(GDB_DOCKER.getHost(), GDB_DOCKER.getMappedPort(PORT));
-        return RefineClients.standard(httpHost.toURI());
+        refineClient = RefineClients.standard(httpHost.toURI());
       } catch (URISyntaxException uriExc) {
         throw new RuntimeException("Failed to create refine client.", uriExc);
       }

--- a/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
+++ b/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
@@ -19,7 +19,7 @@ class RefineClientsTest {
   private static final String URI = "http://ontorefine.com/orefine";
 
   @Test
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings("removal")
   void create_successful() throws URISyntaxException {
     assertNotNull(assertDoesNotThrow(() -> RefineClients.create(URI)));
   }

--- a/src/test/java/com/ontotext/refine/client/SecuredExportIntegrationTest.java
+++ b/src/test/java/com/ontotext/refine/client/SecuredExportIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.ontotext.refine.client;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -8,6 +9,8 @@ import com.ontotext.refine.client.command.RefineCommands;
 import com.ontotext.refine.client.command.create.CreateProjectResponse;
 import com.ontotext.refine.client.command.delete.DeleteProjectResponse;
 import com.ontotext.refine.client.command.rdf.ExportRdfResponse;
+import com.ontotext.refine.client.command.rdf.GraphDbSparqlBasedRdfExportCommand;
+import com.ontotext.refine.client.command.rdf.OutputType;
 import com.ontotext.refine.client.command.rdf.ResultFormat;
 import com.ontotext.refine.client.util.RdfTestUtils;
 import java.io.ByteArrayInputStream;
@@ -76,13 +79,36 @@ class SecuredExportIntegrationTest extends CommandIntegrationTest {
     String query = IOUtils.resourceToString(
         "/integration/netherlands_restaurants_construct_query.sparql",
         StandardCharsets.UTF_8);
-    return RefineCommands
-        .exportRdfUsingSparql()
-        .setProject(projectId)
-        .setFormat(ResultFormat.TURTLE)
-        .setQuery(query)
-        .setRepository(REPO_NAME)
-        .build()
-        .execute(getClient());
+    TestGraphDbSparqlBasedRdfExportCommand command = new TestGraphDbSparqlBasedRdfExportCommand(
+        projectId, "#project_placeholder#", query, ResultFormat.TURTLE, REPO_NAME, null);
+    return command.execute(getClient());
+  }
+
+  // hack for the proxy in order to keep the test and the logic around it, because it is relevant
+  private class TestGraphDbSparqlBasedRdfExportCommand extends GraphDbSparqlBasedRdfExportCommand {
+
+    private TestGraphDbSparqlBasedRdfExportCommand(
+        String project,
+        String placeholder,
+        String query,
+        ResultFormat format,
+        String repository,
+        OutputType output) {
+      super(project, placeholder, query, format, repository, output);
+
+      // verifies the input parameters, also Sonar test coverage
+      GraphDbSparqlBasedRdfExportCommand.Builder builder = RefineCommands
+          .exportRdfUsingSparql()
+          .setProject(project)
+          .setFormat(ResultFormat.TURTLE)
+          .setQuery(query)
+          .setRepository(REPO_NAME);
+      assertDoesNotThrow(() -> builder.build());
+    }
+
+    @Override
+    public String endpoint() {
+      return "/repositories/{repo}";
+    }
   }
 }

--- a/src/test/java/com/ontotext/refine/client/command/rdf/SparqlBasedRdfExportCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/rdf/SparqlBasedRdfExportCommandTest.java
@@ -1,0 +1,101 @@
+package com.ontotext.refine.client.command.rdf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+/**
+ * Test for {@link SparqlBasedRdfExportCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class SparqlBasedRdfExportCommandTest
+    extends BaseCommandTest<ExportRdfResponse, SparqlBasedRdfExportCommand> {
+
+  @Captor
+  private ArgumentCaptor<HttpUriRequest> requestCaptor;
+
+  private String query;
+
+  @BeforeEach
+  void init() throws IOException {
+    query = IOUtils.toString(loadResource("construct.sparql"), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected SparqlBasedRdfExportCommand command() {
+    return commandBuilder().build();
+  }
+
+  private SparqlBasedRdfExportCommand.Builder commandBuilder() {
+    return RefineCommands.exportAsRdf()
+        .setProject(PROJECT_ID)
+        .setPrefix("ontorefine:")
+        .setQuery(query)
+        .setFormat(ResultFormat.TURTLE);
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "rdf/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUri(anyString());
+    verify(client).execute(requestCaptor.capture(), any());
+
+    HttpUriRequest request = requestCaptor.getValue();
+
+    assertEquals(
+        "text/turtle;charset=UTF-8",
+        request.getFirstHeader(HttpHeaders.ACCEPT).getValue());
+  }
+
+  @Test
+  void execute_failure() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exc = assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Export of RDF data failed for project: '" + PROJECT_ID + "' due to: Test error",
+        exc.getMessage());
+
+    verify(client).createUri(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void handleResponse_asFileStream() throws IOException {
+    try (InputStream is = new ByteArrayInputStream("dummy RDF data".getBytes())) {
+      SparqlBasedRdfExportCommand command = commandBuilder().setOutput(OutputType.FILE).build();
+      ExportRdfResponse response =
+          command.handleResponse(okResponse(is, BigInteger.valueOf(Integer.MAX_VALUE)));
+      assertEquals("dummy RDF data", IOUtils.toString(response.getResultStream(), UTF_8));
+    }
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/util/mappings/MappingsNormalizerTest.java
+++ b/src/test/java/com/ontotext/refine/client/util/mappings/MappingsNormalizerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Test for {@link MappingsNormalizer}.
+ * NOT_MAPPING_ASSIGNABLE Test for {@link MappingsNormalizer}.
  *
  * @author Antoniy Kunchev
  */
@@ -32,7 +32,9 @@ class MappingsNormalizerTest {
   @ValueSource(strings = {
       "forRdfExport_mappings.json",
       "forRdfExport_operations.json",
-      "forRdfExport_project-models.json"})
+      "forRdfExport_operations-array.json",
+      "forRdfExport_project-models.json",
+      "forRdfExport_relaxed-case.json"})
   void forRdfExport(String resource) {
     String mappings = loadResource(resource);
 

--- a/src/test/resources/mappings-normalizer/forRdfExport_operations-array.json
+++ b/src/test/resources/mappings-normalizer/forRdfExport_operations-array.json
@@ -1,0 +1,383 @@
+[
+  {
+    "description": "Save RDF Mapping",
+    "operation": {
+      "op": "mapping-editor/save-rdf-mapping",
+      "mapping": {
+        "baseIRI": "http://example/base/",
+        "namespaces": {
+          "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          "schema": "http://schema.org/",
+          "geo": "http://www.opengis.net/ont/geosparql#",
+          "amsterdam": "https://data/amsterdam/nl/resource/",
+          "sf": "http://www.opengis.net/ont/sf#",
+          "xsd": "http://www.w3.org/2001/XMLSchema#",
+          "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        "subjectMappings": [
+          {
+            "propertyMappings": [
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Title",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  },
+                  {
+                    "valueSource": {
+                      "columnName": "TitleEN",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "language_literal",
+                      "language": {
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "english"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "description"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Shortdescription",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "latitude"
+                  }
+                },
+                "values": [
+                  {
+                    "transformation": {
+                      "expression": "value.replace(',','.')",
+                      "language": "grel"
+                    },
+                    "valueSource": {
+                      "source": "row_index"
+                    },
+                    "valueType": {
+                      "type": "datatype_literal",
+                      "datatype": {
+                        "transformation": {
+                          "expression": "xsd",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "float"
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "zipcode"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Zipcode",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "type": "literal"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "schema",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "image"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Media",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [],
+                      "type": "iri",
+                      "typeMappings": []
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "geo",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "hasGeometry"
+                  }
+                },
+                "values": [
+                  {
+                    "transformation": {
+                      "expression": "amsterdam:geometry/",
+                      "language": "prefix"
+                    },
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "geo",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "asWKT"
+                            }
+                          },
+                          "values": [
+                            {
+                              "transformation": {
+                                "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                                "language": "grel"
+                              },
+                              "valueSource": {
+                                "source": "row_index"
+                              },
+                              "valueType": {
+                                "type": "datatype_literal",
+                                "datatype": {
+                                  "transformation": {
+                                    "expression": "geo",
+                                    "language": "prefix"
+                                  },
+                                  "valueSource": {
+                                    "source": "constant",
+                                    "constant": "wktLiteral"
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "iri",
+                      "typeMappings": [
+                        {
+                          "transformation": {
+                            "expression": "sf",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "Point"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "uniquelocation"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "amsterdam",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "address"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "columnName": "Adres",
+                                "source": "column"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "unique_bnode"
+                    }
+                  }
+                ]
+              },
+              {
+                "property": {
+                  "transformation": {
+                    "expression": "amsterdam",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "valuelocation"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "columnName": "Trcid",
+                      "source": "column"
+                    },
+                    "valueType": {
+                      "propertyMappings": [
+                        {
+                          "property": {
+                            "transformation": {
+                              "expression": "amsterdam",
+                              "language": "prefix"
+                            },
+                            "valueSource": {
+                              "source": "constant",
+                              "constant": "city"
+                            }
+                          },
+                          "values": [
+                            {
+                              "valueSource": {
+                                "columnName": "City",
+                                "source": "column"
+                              },
+                              "valueType": {
+                                "type": "literal"
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "type": "value_bnode"
+                    }
+                  }
+                ]
+              }
+            ],
+            "subject": {
+              "transformation": {
+                "expression": "amsterdam:restaurant/",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "columnName": "Trcid",
+                "source": "column"
+              }
+            },
+            "typeMappings": [
+              {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "Restaurant"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "description": "Save RDF Mapping"
+    }
+  },
+  {
+    "description": "Text transform on 725 cells in column City: value.toTitlecase()",
+    "operation": {
+      "op": "core/text-transform",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
+      },
+      "columnName": "City",
+      "expression": "value.toTitlecase()",
+      "onError": "keep-original",
+      "repeat": false,
+      "repeatCount": 10,
+      "description": "Text transform on cells in column City using expression value.toTitlecase()"
+    }
+  }
+]

--- a/src/test/resources/mappings-normalizer/forRdfExport_relaxed-case.json
+++ b/src/test/resources/mappings-normalizer/forRdfExport_relaxed-case.json
@@ -1,0 +1,377 @@
+[
+  {
+    "op": "mapping-editor/save-rdf-mapping",
+    "mapping": {
+      "baseIRI": "http://example/base/",
+      "namespaces": {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "schema": "http://schema.org/",
+        "geo": "http://www.opengis.net/ont/geosparql#",
+        "amsterdam": "https://data/amsterdam/nl/resource/",
+        "sf": "http://www.opengis.net/ont/sf#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#"
+      },
+      "subjectMappings": [
+        {
+          "propertyMappings": [
+            {
+              "property": {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "title"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Title",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                },
+                {
+                  "valueSource": {
+                    "columnName": "TitleEN",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "type": "language_literal",
+                    "language": {
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "english"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "description"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Shortdescription",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "latitude"
+                }
+              },
+              "values": [
+                {
+                  "transformation": {
+                    "expression": "value.replace(',','.')",
+                    "language": "grel"
+                  },
+                  "valueSource": {
+                    "source": "row_index"
+                  },
+                  "valueType": {
+                    "type": "datatype_literal",
+                    "datatype": {
+                      "transformation": {
+                        "expression": "xsd",
+                        "language": "prefix"
+                      },
+                      "valueSource": {
+                        "source": "constant",
+                        "constant": "float"
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "amsterdam",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "zipcode"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Zipcode",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "type": "literal"
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "schema",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "image"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Media",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "propertyMappings": [],
+                    "type": "iri",
+                    "typeMappings": []
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "geo",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "hasGeometry"
+                }
+              },
+              "values": [
+                {
+                  "transformation": {
+                    "expression": "amsterdam:geometry/",
+                    "language": "prefix"
+                  },
+                  "valueSource": {
+                    "columnName": "Trcid",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "transformation": {
+                            "expression": "geo",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "asWKT"
+                          }
+                        },
+                        "values": [
+                          {
+                            "transformation": {
+                              "expression": "\"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT (\" + cells[\"Longitude\"].value.replace(',', '.') + \" \" + cells[\"Latitude\"].value.replace(',', '.')  + \")\"",
+                              "language": "grel"
+                            },
+                            "valueSource": {
+                              "source": "row_index"
+                            },
+                            "valueType": {
+                              "type": "datatype_literal",
+                              "datatype": {
+                                "transformation": {
+                                  "expression": "geo",
+                                  "language": "prefix"
+                                },
+                                "valueSource": {
+                                  "source": "constant",
+                                  "constant": "wktLiteral"
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "type": "iri",
+                    "typeMappings": [
+                      {
+                        "transformation": {
+                          "expression": "sf",
+                          "language": "prefix"
+                        },
+                        "valueSource": {
+                          "source": "constant",
+                          "constant": "Point"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "amsterdam",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "uniquelocation"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Trcid",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "transformation": {
+                            "expression": "amsterdam",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "address"
+                          }
+                        },
+                        "values": [
+                          {
+                            "valueSource": {
+                              "columnName": "Adres",
+                              "source": "column"
+                            },
+                            "valueType": {
+                              "type": "literal"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "type": "unique_bnode"
+                  }
+                }
+              ]
+            },
+            {
+              "property": {
+                "transformation": {
+                  "expression": "amsterdam",
+                  "language": "prefix"
+                },
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "valuelocation"
+                }
+              },
+              "values": [
+                {
+                  "valueSource": {
+                    "columnName": "Trcid",
+                    "source": "column"
+                  },
+                  "valueType": {
+                    "propertyMappings": [
+                      {
+                        "property": {
+                          "transformation": {
+                            "expression": "amsterdam",
+                            "language": "prefix"
+                          },
+                          "valueSource": {
+                            "source": "constant",
+                            "constant": "city"
+                          }
+                        },
+                        "values": [
+                          {
+                            "valueSource": {
+                              "columnName": "City",
+                              "source": "column"
+                            },
+                            "valueType": {
+                              "type": "literal"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "type": "value_bnode"
+                  }
+                }
+              ]
+            }
+          ],
+          "subject": {
+            "transformation": {
+              "expression": "amsterdam:restaurant/",
+              "language": "prefix"
+            },
+            "valueSource": {
+              "columnName": "Trcid",
+              "source": "column"
+            }
+          },
+          "typeMappings": [
+            {
+              "transformation": {
+                "expression": "schema",
+                "language": "prefix"
+              },
+              "valueSource": {
+                "source": "constant",
+                "constant": "Restaurant"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF Mapping"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "City",
+    "expression": "value.toTitlecase()",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column City using expression value.toTitlecase()"
+  }
+]

--- a/src/test/resources/rdf/construct.sparql
+++ b/src/test/resources/rdf/construct.sparql
@@ -1,0 +1,8 @@
+BASE <http://example.com/base/>
+
+CONSTRUCT {
+    ?subject <title> ?o_title .
+} WHERE {
+    BIND(<subject> as ?subject)
+    BIND(STR(?c_Title) as ?o_title)
+}


### PR DESCRIPTION
- Added new command for RDF export of the data of a specific refine
project. The command uses the SPARQL endpoint that Ontotext Refine
exposes, allowing us to execute queries over the refine poject data.
- Added few workarounds for the previous command for RDF export. It is
still using a GraphDB to execute the SPARQL queries, but now it uses
proxy endpoint exposed in Ontotext Refine which routes the request to
the connected GraphDB. The command class was renamed and some usage
notes were added.
- Added new profile in the pom configurations. It is intended to the
used for local test builds of the project, when the user wants to skip
the dependencies and code style checks.