### PR TITLE
Prepares the project for the new development phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Ontotext OntoRefine Client Library
 
+## Version 1.7.1
+
+### New
+
+ - TBD
+
+### Changes
+
+ - TBD
+
+### Bug fixes
+
+ - Fixed the publishing of the library in the Maven Repository, when new release is created. The problem was that the URL for the repository was still using `HTTP`
+   protocol instead of `HTTPS`, which caused an error while uploading the artifacts into the repository.
+
+
 ## Version 1.7
 
 ### New

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.ontotext</groupId>
     <artifactId>ontorefine-client</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>An Ontotext Refine Client Library</description>
@@ -39,7 +39,7 @@
         <repository>
             <id>all-onto</id>
             <name>Ontotext Public Maven</name>
-            <url>http://maven.ontotext.com/content/repositories/public</url>
+            <url>https://maven.ontotext.com/content/repositories/public</url>
         </repository>
     </distributionManagement>
 


### PR DESCRIPTION
- Changed the project version to `1.7.1-SNAPSHOT`.
- Added entry for the new version in the CHANGELOG document.
- Potentially fixed the deployment of the artifacts in the Maven
Repository, when new version is released.