### PR TITLE
Fixes an issues with the string serialization of the Engines options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### New
 
- - TBD
-
+ - Added `record-based` options for the `Engines` enum. The reason is completeness.
+ 
 ### Changes
 
  - TBD
@@ -14,7 +14,8 @@
 
  - Fixed the publishing of the library in the Maven Repository, when new release is created. The problem was that the URL for the repository was still using `HTTP`
    protocol instead of `HTTPS`, which caused an error while uploading the artifacts into the repository.
-
+ - Fixed the string serialization of the `Engines` enum values. The previous mechanism was causing parsing errors in the OpenRefine, when the `export` command was
+   executed.
 
 ## Version 1.7
 

--- a/src/main/java/com/ontotext/refine/client/command/export/Engines.java
+++ b/src/main/java/com/ontotext/refine/client/command/export/Engines.java
@@ -1,7 +1,8 @@
 package com.ontotext.refine.client.command.export;
 
+import static com.ontotext.refine.client.util.OrcJsonFactory.object;
+
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 /**
  * Provides a engine options for the {@link ExportRowsCommand}.
@@ -10,7 +11,9 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
  */
 public enum Engines {
 
-  ROW_BASED(JsonNodeFactory.instance.objectNode().put("mode", "row-based"));
+  ROW_BASED(object().put("mode", "row-based")),
+
+  RECORD_BASED(object().put("mode", "record-based"));
 
   private final JsonNode engine;
 
@@ -25,6 +28,6 @@ public enum Engines {
    *         refine tool
    */
   public String get() {
-    return engine.asText();
+    return engine.toString();
   }
 }

--- a/src/main/java/com/ontotext/refine/client/util/OrcJsonFactory.java
+++ b/src/main/java/com/ontotext/refine/client/util/OrcJsonFactory.java
@@ -1,0 +1,31 @@
+package com.ontotext.refine.client.util;
+
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Utility containing convenient methods for building JSON documents using the Jackson API.
+ *
+ * @author Antoniy Kunchev
+ */
+public enum OrcJsonFactory {
+  ;
+
+  /**
+   * Shortcut method providing access to the {@link JsonNodeFactory#instance}.
+   *
+   * @return standard {@link JsonNodeFactory} instance
+   */
+  public static JsonNodeFactory get() {
+    return JsonNodeFactory.instance;
+  }
+
+  /**
+   * Shortcut method for {@link JsonNodeFactory#objectNode()}.
+   *
+   * @return new {@link ObjectNode} instance
+   */
+  public static ObjectNode object() {
+    return get().objectNode();
+  }
+}


### PR DESCRIPTION
- Changed the string serialization mechanism of the `Engines` options.
The previous way was causing parsing errors in `OpenRefine` when
execution the command for export.
- Added new option in the `Engines` called `record-based` for
completeness.
- Added new utility which contains convenient methods for building JSON
documents.