### PR TITLE
Export project configurations command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@
 
 ### New
 
- - TBD
+ - Introduced new command for retrieval of project configurations, which is based on the Refine extension. This extension provides a way for the users to export more
+   complete set of configurations for a project so that they can be reused for creation of other projects. The configurations include the import options for the uploaded
+   dataset and the operations history of the project.
+   The primary reason for the extension is the usage of this configuration in the CLI transformation pipelines. Therefore the CLI commands will be updated to accept and
+   work this configuration.
 
 ### Changes
 
- - TBD
+ - Removed old `create` method from `RefineClients`. The method was deprecated and announced for removal in version `1.4`. All of the related logic and tests were either
+   updated or removed.
+ - Updates the version of all third party dependencies used by the project. This is done in order to keep the project up-to-date and avoid potential security issues due
+   vulnerabilities in the libraries.
 
 ### Bug fixes
 
@@ -19,7 +26,7 @@
 
 ### New
 
- - Added `record-based` options for the `Engines` enum. The reason is completeness.
+ - Added `record-based` options for the `Engines` enum. The reason is, completeness.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 
 ### Bug fixes
 
- - TBD
+ - Fixed the error messages for creation of the projects. The expected response code from the operation is usually `302`. When the code is different, the produced error
+   message is rather misleading, then helpful. There are cases when the code is `200` and the user receives message for error with status code `200`.
 
 
 ## Version 1.7.1

--- a/pom.xml
+++ b/pom.xml
@@ -58,20 +58,20 @@
 
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
-        <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
+        <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-        <dependency.check.plugin.version>7.1.1</dependency.check.plugin.version>
+        <dependency.check.plugin.version>7.3.2</dependency.check.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
 
         <httpcomponents.version>4.5.13</httpcomponents.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.io.version>2.11.0</commons.io.version>
-        <jackson.databind.version>2.13.3</jackson.databind.version>
-        <rdf4j.version>4.1.0</rdf4j.version>
+        <jackson.databind.version>2.14.1</jackson.databind.version>
+        <rdf4j.version>4.2.1</rdf4j.version>
 
-        <junit.jupiter.version>5.9.0</junit.jupiter.version>
-        <mockito.version>4.6.1</mockito.version>
-        <testcontainers.version>1.17.3</testcontainers.version>
+        <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <mockito.version>4.9.0</mockito.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <e2e.graphdb.docker.image>ontotext/graphdb:10.0.0-M1</e2e.graphdb.docker.image>
 
         <checkstyle.enabled>true</checkstyle.enabled>

--- a/src/main/java/com/ontotext/refine/client/ProjectMetadata.java
+++ b/src/main/java/com/ontotext/refine/client/ProjectMetadata.java
@@ -1,5 +1,8 @@
 package com.ontotext.refine.client;
 
+/**
+ * Represents part of the project metadata model.
+ */
 public class ProjectMetadata {
 
   private String name;

--- a/src/main/java/com/ontotext/refine/client/RefineClients.java
+++ b/src/main/java/com/ontotext/refine/client/RefineClients.java
@@ -19,20 +19,6 @@ public interface RefineClients {
   /**
    * Creates default {@link RefineClient} instance.
    *
-   * @deprecated use {@link #standard(String)} instead
-   * @param uri to be used as base for the commands execution. Basically the address of the Refine
-   *        tool instance
-   * @return new default {@link RefineClient} instance
-   * @throws URISyntaxException when the input <code>uri</code> argument is invalid
-   */
-  @Deprecated(since = "1.4", forRemoval = true)
-  static RefineClient create(String uri) throws URISyntaxException {
-    return standard(uri);
-  }
-
-  /**
-   * Creates default {@link RefineClient} instance.
-   *
    * @param uri to be used as base for the commands execution. Basically the address of the Refine
    *        tool instance
    * @return new default {@link RefineClient} instance

--- a/src/main/java/com/ontotext/refine/client/command/GetProjectMetadataResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/GetProjectMetadataResponse.java
@@ -2,6 +2,9 @@ package com.ontotext.refine.client.command;
 
 import com.ontotext.refine.client.ProjectMetadata;
 
+/**
+ * Holds the response from {@link GetProjectMetadataCommand}.
+ */
 public class GetProjectMetadataResponse {
 
   private final ProjectMetadata projectMetadata;

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
@@ -10,6 +10,7 @@ import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.command.preferences.GetPreferenceCommand;
 import com.ontotext.refine.client.command.preferences.SetPreferenceCommand;
 import com.ontotext.refine.client.command.processes.GetProcessesCommand;
+import com.ontotext.refine.client.command.project.configurations.GetProjectConfigurationsCommand;
 import com.ontotext.refine.client.command.rdf.DefaultRdfExportCommand;
 import com.ontotext.refine.client.command.rdf.GraphDbSparqlBasedRdfExportCommand;
 import com.ontotext.refine.client.command.rdf.SparqlBasedRdfExportCommand;
@@ -195,5 +196,14 @@ public interface RefineCommands {
    */
   static GetPreferenceCommand.Builder getPreference() {
     return new GetPreferenceCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link GetProjectConfigurationsCommand}.
+   *
+   * @return new builder instance
+   */
+  static GetProjectConfigurationsCommand.Builder getProjectConfigurations() {
+    return new GetProjectConfigurationsCommand.Builder();
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/create/CreateProjectCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/create/CreateProjectCommand.java
@@ -1,6 +1,5 @@
 package com.ontotext.refine.client.command.create;
 
-import static com.ontotext.refine.client.util.HttpParser.HTTP_PARSER;
 import static org.apache.commons.lang3.Validate.notBlank;
 import static org.apache.commons.lang3.Validate.notNull;
 import static org.apache.http.HttpHeaders.ACCEPT;
@@ -91,11 +90,18 @@ public class CreateProjectCommand implements RefineCommand<CreateProjectResponse
   @Override
   public CreateProjectResponse handleResponse(HttpResponse response) throws IOException {
     // TODO: parse errors in refine are returned as HTML
-    HTTP_PARSER.assureStatusCode(response, SC_MOVED_TEMPORARILY);
+    if (SC_MOVED_TEMPORARILY != response.getStatusLine().getStatusCode()) {
+      throw new RefineException(
+          "Failed to create refine project. Please ensure that all of the provided configurations"
+              + " and data are correct.");
+    }
+
     Header location = response.getFirstHeader("Location");
     if (location == null) {
-      throw new RefineException("No location header found.");
+      throw new RefineException(
+          "No location header found. The header is required for the project identifier retrieval.");
     }
+
     URL url = new URL("http", "", location.getValue());
     return new CreateProjectResponse(url);
   }

--- a/src/main/java/com/ontotext/refine/client/command/export/ExportRowsResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/export/ExportRowsResponse.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 /**
  * Holds the result from the {@link ExportRowsCommand}.
- * 
+ *
  * @author Antoniy Kunchev
  */
 public class ExportRowsResponse {

--- a/src/main/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommandResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/preferences/SetPreferenceCommandResponse.java
@@ -4,10 +4,9 @@ import com.ontotext.refine.client.RefineResponse;
 import com.ontotext.refine.client.ResponseCode;
 import org.apache.commons.lang3.Validate;
 
-
 /**
  * Holds the response from {@link SetPreferenceCommand}.
- * 
+ *
  * @author Antoniy Kunchev
  */
 public class SetPreferenceCommandResponse extends RefineResponse {

--- a/src/main/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsCommand.java
@@ -1,0 +1,97 @@
+package com.ontotext.refine.client.command.project.configurations;
+
+import static com.ontotext.refine.client.command.RefineCommand.Constants.PROJECT;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.command.operations.GetOperationsCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import com.ontotext.refine.client.util.HttpParser;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+
+/**
+ * A command that retrieves the configurations for specified project. The command depends on the
+ * 'project-configurations` extension in order to work.
+ *
+ * @author Antoniy Kunchev
+ */
+public class GetProjectConfigurationsCommand
+    implements RefineCommand<GetProjectConfigurationsResponse> {
+
+  private final String project;
+
+  private GetProjectConfigurationsCommand(String project) {
+    this.project = project;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/orefine/command/project-configurations/export";
+  }
+
+  @Override
+  public GetProjectConfigurationsResponse execute(RefineClient client) throws RefineException {
+    try {
+      HttpUriRequest request = RequestBuilder
+          .get(client.createUri(endpoint()))
+          .addParameter(PROJECT, project)
+          .build();
+
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      String error = String.format(
+          "Failed to retrieve the configurations of project: '%s' due to: %s",
+          project,
+          ioe.getMessage());
+      throw new RefineException(error);
+    }
+  }
+
+  @Override
+  public GetProjectConfigurationsResponse handleResponse(HttpResponse response) throws IOException {
+    if (response.getStatusLine().getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+      throw new RefineException("Unable to retrieve the project configurations. Ensure that the"
+          + " extension is installed on the Refine instance that you are trying to access.");
+    }
+
+    HttpParser.HTTP_PARSER.assureStatusCode(response, HttpStatus.SC_OK);
+    try (InputStream stream = response.getEntity().getContent()) {
+      JsonMapper mapper = new JsonMapper();
+      return new GetProjectConfigurationsResponse()
+          .setContent(mapper.readTree(stream))
+          .setProject(project);
+    }
+  }
+
+  /**
+   * Builder for {@link GetProjectConfigurationsCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String project;
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    /**
+     * Builds the {@link GetOperationsCommand}.
+     *
+     * @return a command
+     */
+    public GetProjectConfigurationsCommand build() {
+      Validate.notBlank(project, "Missing 'project' argument");
+      return new GetProjectConfigurationsCommand(project);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsResponse.java
@@ -1,0 +1,51 @@
+package com.ontotext.refine.client.command.project.configurations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+
+/**
+ * Holds the response from the {@link GetProjectConfigurationsCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+public class GetProjectConfigurationsResponse {
+
+  private String project;
+  private JsonNode content;
+
+  public String getProject() {
+    return project;
+  }
+
+  public GetProjectConfigurationsResponse setProject(String project) {
+    this.project = project;
+    return this;
+  }
+
+  public JsonNode getContent() {
+    return content;
+  }
+
+  public GetProjectConfigurationsResponse setContent(JsonNode content) {
+    this.content = content;
+    return this;
+  }
+
+  /**
+   * Retrieves the project import options from the result content.
+   *
+   * @return import options if found, otherwise empty optional
+   */
+  public Optional<JsonNode> getImportOptions() {
+    return Optional.ofNullable(content.get("importOptions"));
+  }
+
+  /**
+   * Retrieves the project operations history from the result content.
+   *
+   * @return operations history if found, otherwise empty optional
+   */
+  public Optional<JsonNode> getOperations() {
+    return Optional.ofNullable(content.get("operations"));
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/reconcile/GuessColumnTypeCommandResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/reconcile/GuessColumnTypeCommandResponse.java
@@ -127,7 +127,7 @@ public class GuessColumnTypeCommandResponse {
 
     @Override
     public int hashCode() {
-      return Objects.hash(count, id,name, score);
+      return Objects.hash(count, id, name, score);
     }
 
     @Override

--- a/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
+++ b/src/test/java/com/ontotext/refine/client/RefineClientsTest.java
@@ -19,12 +19,6 @@ class RefineClientsTest {
   private static final String URI = "http://ontorefine.com/orefine";
 
   @Test
-  @SuppressWarnings("removal")
-  void create_successful() throws URISyntaxException {
-    assertNotNull(assertDoesNotThrow(() -> RefineClients.create(URI)));
-  }
-
-  @Test
   void securityAware_exceptionOnMissingCredsProvider() throws URISyntaxException {
     assertThrows(NullPointerException.class, () -> RefineClients.securityAware(URI, null));
   }

--- a/src/test/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/project/configurations/GetProjectConfigurationsCommandTest.java
@@ -1,0 +1,83 @@
+package com.ontotext.refine.client.command.project.configurations;
+
+import static com.ontotext.refine.client.util.JsonParser.JSON_PARSER;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.http.HttpVersion;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link GetProjectConfigurationsCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class GetProjectConfigurationsCommandTest
+    extends BaseCommandTest<GetProjectConfigurationsResponse, GetProjectConfigurationsCommand> {
+
+  @Override
+  protected GetProjectConfigurationsCommand command() {
+    return RefineCommands.getProjectConfigurations().setProject(PROJECT_ID).build();
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "project-configurations/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUri(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void execute_failure() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exception =
+        assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Failed to retrieve the configurations of project: '1234567890987' due to: Test error",
+        exception.getMessage());
+
+    verify(client).createUri(anyString());
+    verify(client).execute(any(), any());
+  }
+
+  @Test
+  void handleResponse_notFound() throws IOException {
+    BasicHttpResponse response =
+        new BasicHttpResponse(new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "NOT FOUND"));
+    assertThrows(RefineException.class, () -> command().handleResponse(response));
+  }
+
+  @Test
+  void handleResponse_successful() throws IOException {
+    GetProjectConfigurationsResponse response = command()
+        .handleResponse(okResponse(loadResource("getProjectConfigurations_response.json")));
+
+    JsonNode expected =
+        JSON_PARSER.parseJson(loadResource("getProjectConfigurations_expected.json"));
+    assertEquals(expected, response.getContent());
+
+    assertTrue(response.getImportOptions().isPresent());
+    assertTrue(response.getOperations().isPresent());
+  }
+}

--- a/src/test/resources/project-configurations/getProjectConfigurations_expected.json
+++ b/src/test/resources/project-configurations/getProjectConfigurations_expected.json
@@ -1,0 +1,198 @@
+{
+  "importOptions": [
+    {
+      "encoding": "",
+      "separator": ",",
+      "ignoreLines": -1,
+      "headerLines": 1,
+      "skipDataLines": 0,
+      "limit": -1,
+      "storeBlankRows": true,
+      "guessCellValueTypes": false,
+      "processQuotes": true,
+      "quoteCharacter": "\"",
+      "storeBlankCellsAsNulls": true,
+      "includeFileSources": false,
+      "projectName": "Netherlands_restaurants-17.08",
+      "projectTags": [
+        ""
+      ],
+      "fileSource": "Netherlands_restaurants-csv.csv"
+    }
+  ],
+  "operations": [
+    {
+      "operation": {
+        "op": "core/recon",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "columnName": "City",
+        "config": {
+          "mode": "standard-service",
+          "service": "https://wikidata.reconci.link/en/api",
+          "identifierSpace": "http://www.wikidata.org/entity/",
+          "schemaSpace": "http://www.wikidata.org/prop/direct/",
+          "type": {
+            "id": "Q1852859",
+            "name": "populated place in the Netherlands"
+          },
+          "autoMatch": true,
+          "columnDetails": [],
+          "limit": 0
+        },
+        "description": "Reconcile cells in column City to type Q1852859"
+      },
+      "description": "Reconcile cells in column City to type Q1852859"
+    },
+    {
+      "operation": {
+        "op": "core/extend-reconciled-data",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "baseColumnName": "City",
+        "endpoint": "https://wikidata.reconci.link/en/api",
+        "identifierSpace": "http://www.wikidata.org/entity/",
+        "schemaSpace": "http://www.wikidata.org/prop/direct/",
+        "extension": {
+          "properties": [
+            {
+              "id": "P17",
+              "name": null
+            },
+            {
+              "id": "P625",
+              "name": null
+            },
+            {
+              "id": "P1082",
+              "name": null
+            }
+          ]
+        },
+        "columnInsertIndex": 13,
+        "description": "Extend data at index 13 based on column City"
+      },
+      "description": "Extend data at index 13 based on column City"
+    },
+    {
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example.com/base/",
+          "namespaces": {},
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      },
+      "description": "Save RDF Mapping"
+    },
+    {
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example.com/base/",
+          "namespaces": {},
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "population"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "population"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      },
+      "description": "Save RDF Mapping"
+    }
+  ]
+}

--- a/src/test/resources/project-configurations/getProjectConfigurations_expected.json
+++ b/src/test/resources/project-configurations/getProjectConfigurations_expected.json
@@ -22,175 +22,163 @@
   ],
   "operations": [
     {
-      "operation": {
-        "op": "core/recon",
-        "engineConfig": {
-          "facets": [],
-          "mode": "row-based"
+      "op": "core/recon",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
+      },
+      "columnName": "City",
+      "config": {
+        "mode": "standard-service",
+        "service": "https://wikidata.reconci.link/en/api",
+        "identifierSpace": "http://www.wikidata.org/entity/",
+        "schemaSpace": "http://www.wikidata.org/prop/direct/",
+        "type": {
+          "id": "Q1852859",
+          "name": "populated place in the Netherlands"
         },
-        "columnName": "City",
-        "config": {
-          "mode": "standard-service",
-          "service": "https://wikidata.reconci.link/en/api",
-          "identifierSpace": "http://www.wikidata.org/entity/",
-          "schemaSpace": "http://www.wikidata.org/prop/direct/",
-          "type": {
-            "id": "Q1852859",
-            "name": "populated place in the Netherlands"
-          },
-          "autoMatch": true,
-          "columnDetails": [],
-          "limit": 0
-        },
-        "description": "Reconcile cells in column City to type Q1852859"
+        "autoMatch": true,
+        "columnDetails": [],
+        "limit": 0
       },
       "description": "Reconcile cells in column City to type Q1852859"
     },
     {
-      "operation": {
-        "op": "core/extend-reconciled-data",
-        "engineConfig": {
-          "facets": [],
-          "mode": "row-based"
-        },
-        "baseColumnName": "City",
-        "endpoint": "https://wikidata.reconci.link/en/api",
-        "identifierSpace": "http://www.wikidata.org/entity/",
-        "schemaSpace": "http://www.wikidata.org/prop/direct/",
-        "extension": {
-          "properties": [
-            {
-              "id": "P17",
-              "name": null
-            },
-            {
-              "id": "P625",
-              "name": null
-            },
-            {
-              "id": "P1082",
-              "name": null
-            }
-          ]
-        },
-        "columnInsertIndex": 13,
-        "description": "Extend data at index 13 based on column City"
+      "op": "core/extend-reconciled-data",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
       },
+      "baseColumnName": "City",
+      "endpoint": "https://wikidata.reconci.link/en/api",
+      "identifierSpace": "http://www.wikidata.org/entity/",
+      "schemaSpace": "http://www.wikidata.org/prop/direct/",
+      "extension": {
+        "properties": [
+          {
+            "id": "P17",
+            "name": null
+          },
+          {
+            "id": "P625",
+            "name": null
+          },
+          {
+            "id": "P1082",
+            "name": null
+          }
+        ]
+      },
+      "columnInsertIndex": 13,
       "description": "Extend data at index 13 based on column City"
     },
     {
-      "operation": {
-        "op": "mapping-editor/save-rdf-mapping",
-        "mapping": {
-          "baseIRI": "http://example.com/base/",
-          "namespaces": {},
-          "subjectMappings": [
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
+      "op": "mapping-editor/save-rdf-mapping",
+      "mapping": {
+        "baseIRI": "http://example.com/base/",
+        "namespaces": {},
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
+            },
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
                     "valueSource": {
-                      "source": "constant",
-                      "constant": "title"
+                      "source": "column",
+                      "columnName": "Title"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "Title"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "description": "Save RDF Mapping"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "description": "Save RDF Mapping"
     },
     {
-      "operation": {
-        "op": "mapping-editor/save-rdf-mapping",
-        "mapping": {
-          "baseIRI": "http://example.com/base/",
-          "namespaces": {},
-          "subjectMappings": [
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
-                    "valueSource": {
-                      "source": "constant",
-                      "constant": "title"
-                    }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "Title"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
-                    }
-                  ]
-                }
-              ]
+      "op": "mapping-editor/save-rdf-mapping",
+      "mapping": {
+        "baseIRI": "http://example.com/base/",
+        "namespaces": {},
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
             },
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
                     "valueSource": {
-                      "source": "constant",
-                      "constant": "population"
+                      "source": "column",
+                      "columnName": "Title"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "population"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
+            },
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "population"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "population"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "description": "Save RDF Mapping"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "description": "Save RDF Mapping"
     }

--- a/src/test/resources/project-configurations/getProjectConfigurations_response.json
+++ b/src/test/resources/project-configurations/getProjectConfigurations_response.json
@@ -1,0 +1,198 @@
+{
+  "importOptions": [
+    {
+      "encoding": "",
+      "separator": ",",
+      "ignoreLines": -1,
+      "headerLines": 1,
+      "skipDataLines": 0,
+      "limit": -1,
+      "storeBlankRows": true,
+      "guessCellValueTypes": false,
+      "processQuotes": true,
+      "quoteCharacter": "\"",
+      "storeBlankCellsAsNulls": true,
+      "includeFileSources": false,
+      "projectName": "Netherlands_restaurants-17.08",
+      "projectTags": [
+        ""
+      ],
+      "fileSource": "Netherlands_restaurants-csv.csv"
+    }
+  ],
+  "operations": [
+    {
+      "operation": {
+        "op": "core/recon",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "columnName": "City",
+        "config": {
+          "mode": "standard-service",
+          "service": "https://wikidata.reconci.link/en/api",
+          "identifierSpace": "http://www.wikidata.org/entity/",
+          "schemaSpace": "http://www.wikidata.org/prop/direct/",
+          "type": {
+            "id": "Q1852859",
+            "name": "populated place in the Netherlands"
+          },
+          "autoMatch": true,
+          "columnDetails": [],
+          "limit": 0
+        },
+        "description": "Reconcile cells in column City to type Q1852859"
+      },
+      "description": "Reconcile cells in column City to type Q1852859"
+    },
+    {
+      "operation": {
+        "op": "core/extend-reconciled-data",
+        "engineConfig": {
+          "facets": [],
+          "mode": "row-based"
+        },
+        "baseColumnName": "City",
+        "endpoint": "https://wikidata.reconci.link/en/api",
+        "identifierSpace": "http://www.wikidata.org/entity/",
+        "schemaSpace": "http://www.wikidata.org/prop/direct/",
+        "extension": {
+          "properties": [
+            {
+              "id": "P17",
+              "name": null
+            },
+            {
+              "id": "P625",
+              "name": null
+            },
+            {
+              "id": "P1082",
+              "name": null
+            }
+          ]
+        },
+        "columnInsertIndex": 13,
+        "description": "Extend data at index 13 based on column City"
+      },
+      "description": "Extend data at index 13 based on column City"
+    },
+    {
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example.com/base/",
+          "namespaces": {},
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      },
+      "description": "Save RDF Mapping"
+    },
+    {
+      "operation": {
+        "op": "mapping-editor/save-rdf-mapping",
+        "mapping": {
+          "baseIRI": "http://example.com/base/",
+          "namespaces": {},
+          "subjectMappings": [
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "title"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "Title"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "subject": {
+                "valueSource": {
+                  "source": "constant",
+                  "constant": "subject"
+                }
+              },
+              "typeMappings": [],
+              "propertyMappings": [
+                {
+                  "property": {
+                    "valueSource": {
+                      "source": "constant",
+                      "constant": "population"
+                    }
+                  },
+                  "values": [
+                    {
+                      "valueSource": {
+                        "source": "column",
+                        "columnName": "population"
+                      },
+                      "valueType": {
+                        "type": "literal"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "description": "Save RDF Mapping"
+      },
+      "description": "Save RDF Mapping"
+    }
+  ]
+}

--- a/src/test/resources/project-configurations/getProjectConfigurations_response.json
+++ b/src/test/resources/project-configurations/getProjectConfigurations_response.json
@@ -22,175 +22,163 @@
   ],
   "operations": [
     {
-      "operation": {
-        "op": "core/recon",
-        "engineConfig": {
-          "facets": [],
-          "mode": "row-based"
+      "op": "core/recon",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
+      },
+      "columnName": "City",
+      "config": {
+        "mode": "standard-service",
+        "service": "https://wikidata.reconci.link/en/api",
+        "identifierSpace": "http://www.wikidata.org/entity/",
+        "schemaSpace": "http://www.wikidata.org/prop/direct/",
+        "type": {
+          "id": "Q1852859",
+          "name": "populated place in the Netherlands"
         },
-        "columnName": "City",
-        "config": {
-          "mode": "standard-service",
-          "service": "https://wikidata.reconci.link/en/api",
-          "identifierSpace": "http://www.wikidata.org/entity/",
-          "schemaSpace": "http://www.wikidata.org/prop/direct/",
-          "type": {
-            "id": "Q1852859",
-            "name": "populated place in the Netherlands"
-          },
-          "autoMatch": true,
-          "columnDetails": [],
-          "limit": 0
-        },
-        "description": "Reconcile cells in column City to type Q1852859"
+        "autoMatch": true,
+        "columnDetails": [],
+        "limit": 0
       },
       "description": "Reconcile cells in column City to type Q1852859"
     },
     {
-      "operation": {
-        "op": "core/extend-reconciled-data",
-        "engineConfig": {
-          "facets": [],
-          "mode": "row-based"
-        },
-        "baseColumnName": "City",
-        "endpoint": "https://wikidata.reconci.link/en/api",
-        "identifierSpace": "http://www.wikidata.org/entity/",
-        "schemaSpace": "http://www.wikidata.org/prop/direct/",
-        "extension": {
-          "properties": [
-            {
-              "id": "P17",
-              "name": null
-            },
-            {
-              "id": "P625",
-              "name": null
-            },
-            {
-              "id": "P1082",
-              "name": null
-            }
-          ]
-        },
-        "columnInsertIndex": 13,
-        "description": "Extend data at index 13 based on column City"
+      "op": "core/extend-reconciled-data",
+      "engineConfig": {
+        "facets": [],
+        "mode": "row-based"
       },
+      "baseColumnName": "City",
+      "endpoint": "https://wikidata.reconci.link/en/api",
+      "identifierSpace": "http://www.wikidata.org/entity/",
+      "schemaSpace": "http://www.wikidata.org/prop/direct/",
+      "extension": {
+        "properties": [
+          {
+            "id": "P17",
+            "name": null
+          },
+          {
+            "id": "P625",
+            "name": null
+          },
+          {
+            "id": "P1082",
+            "name": null
+          }
+        ]
+      },
+      "columnInsertIndex": 13,
       "description": "Extend data at index 13 based on column City"
     },
     {
-      "operation": {
-        "op": "mapping-editor/save-rdf-mapping",
-        "mapping": {
-          "baseIRI": "http://example.com/base/",
-          "namespaces": {},
-          "subjectMappings": [
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
+      "op": "mapping-editor/save-rdf-mapping",
+      "mapping": {
+        "baseIRI": "http://example.com/base/",
+        "namespaces": {},
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
+            },
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
                     "valueSource": {
-                      "source": "constant",
-                      "constant": "title"
+                      "source": "column",
+                      "columnName": "Title"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "Title"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "description": "Save RDF Mapping"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "description": "Save RDF Mapping"
     },
     {
-      "operation": {
-        "op": "mapping-editor/save-rdf-mapping",
-        "mapping": {
-          "baseIRI": "http://example.com/base/",
-          "namespaces": {},
-          "subjectMappings": [
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
-                    "valueSource": {
-                      "source": "constant",
-                      "constant": "title"
-                    }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "Title"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
-                    }
-                  ]
-                }
-              ]
+      "op": "mapping-editor/save-rdf-mapping",
+      "mapping": {
+        "baseIRI": "http://example.com/base/",
+        "namespaces": {},
+        "subjectMappings": [
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
             },
-            {
-              "subject": {
-                "valueSource": {
-                  "source": "constant",
-                  "constant": "subject"
-                }
-              },
-              "typeMappings": [],
-              "propertyMappings": [
-                {
-                  "property": {
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "title"
+                  }
+                },
+                "values": [
+                  {
                     "valueSource": {
-                      "source": "constant",
-                      "constant": "population"
+                      "source": "column",
+                      "columnName": "Title"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  },
-                  "values": [
-                    {
-                      "valueSource": {
-                        "source": "column",
-                        "columnName": "population"
-                      },
-                      "valueType": {
-                        "type": "literal"
-                      }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "subject": {
+              "valueSource": {
+                "source": "constant",
+                "constant": "subject"
+              }
+            },
+            "typeMappings": [],
+            "propertyMappings": [
+              {
+                "property": {
+                  "valueSource": {
+                    "source": "constant",
+                    "constant": "population"
+                  }
+                },
+                "values": [
+                  {
+                    "valueSource": {
+                      "source": "column",
+                      "columnName": "population"
+                    },
+                    "valueType": {
+                      "type": "literal"
                     }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        "description": "Save RDF Mapping"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "description": "Save RDF Mapping"
     }


### PR DESCRIPTION
Introduces new command for export of project configurations

- Added new command, which exports project configurations. These
configurations provide information about the project import options and
operations history.

  The main idea is to provide to the users more complete set of
configurations that they can reuse to process similar datasets. The
focus is to update the Ontotext Refine CLI to work and process such
configurations in the different commands that it provides, thus making
the creation of the transformation pipeline more simple.

  The endpoint and the functionality for the configurations is provided
by an Refine extensions and the current command depends on it in order
to work.

- Removed `RefineClients#create` method and all of the related logic. It
was marked as deprecated and for removal in version `1.4`.

- Updated some of the third party libraries in order to keep them
up-to-date and prevent security issues.

- Fixed some code issues detected by the new version of the checkstyle
plugin.

---
Updates the error responses for creation of project command

- The expected response code from create project command is usually
`302`, but when there is a problem, the Refine returns `200`. The
propagated message to the user is that there was an unexpected error,
but the status code is `200`, which is confusing and misleading.
  Now the messages from such errors are fixed in order to provide
details about the error rather then bringing more confusion.