### PR TITLE
Project aliases commands and other bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
    dataset and the operations history of the project.
    The primary reason for the extension is the usage of this configuration in the CLI transformation pipelines. Therefore the CLI commands will be updated to accept and
    work this configuration.
+ - Introduced new command for identifying project by using alias or project id. The command is related to the new functionality introduced in Ontotext Refine 1.2, where
+   the users are able to assign aliases to the projects and afterwards using them as reference.
+ - Introduced new command for updating project alias(es). As the command for the project identification, it is related to the new functionality in Ontotext Refine 1.2.
+   The command can be used to add and/or remove alias(es) from a specific project.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
  - Fixed the error messages for creation of the projects. The expected response code from the operation is usually `302`. When the code is different, the produced error
    message is rather misleading, then helpful. There are cases when the code is `200` and the user receives message for error with status code `200`.
+ - Fixed an issue with the provision of the `options` for the create project command. It is related to the way the arguments are expected and handled in the OpenRefine.
+   Basically The `options` should be provided as query parameters to the request, instead of as part of the request payload.
 
 
 ## Version 1.7.1

--- a/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
+++ b/src/main/java/com/ontotext/refine/client/command/RefineCommands.java
@@ -10,6 +10,8 @@ import com.ontotext.refine.client.command.operations.GetOperationsCommand;
 import com.ontotext.refine.client.command.preferences.GetPreferenceCommand;
 import com.ontotext.refine.client.command.preferences.SetPreferenceCommand;
 import com.ontotext.refine.client.command.processes.GetProcessesCommand;
+import com.ontotext.refine.client.command.project.aliases.IdentifyProjectCommand;
+import com.ontotext.refine.client.command.project.aliases.UpdateProjectAliasesCommand;
 import com.ontotext.refine.client.command.project.configurations.GetProjectConfigurationsCommand;
 import com.ontotext.refine.client.command.rdf.DefaultRdfExportCommand;
 import com.ontotext.refine.client.command.rdf.GraphDbSparqlBasedRdfExportCommand;
@@ -199,11 +201,33 @@ public interface RefineCommands {
   }
 
   /**
-   * Provides a builder instance for the {@link GetProjectConfigurationsCommand}.
+   * Provides a builder instance for the {@link GetProjectConfigurationsCommand}.<br>
+   * The command requires 'project-configurations' extension.<br>
+   * This extension is added by default to Ontotext Refine version 1.2 and above.
    *
    * @return new builder instance
    */
   static GetProjectConfigurationsCommand.Builder getProjectConfigurations() {
     return new GetProjectConfigurationsCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link IdentifyProjectCommand}.<br>
+   * The command requires Ontotext Refine version 1.2 and above.
+   *
+   * @return new builder instance
+   */
+  static IdentifyProjectCommand.Builder identifyProject() {
+    return new IdentifyProjectCommand.Builder();
+  }
+
+  /**
+   * Provides a builder instance for the {@link UpdateProjectAliasesCommand}.<br>
+   * The command requires Ontotext Refine version 1.2 and above.
+   *
+   * @return new builder instance
+   */
+  static UpdateProjectAliasesCommand.Builder updateProjectAliases() {
+    return new UpdateProjectAliasesCommand.Builder();
   }
 }

--- a/src/main/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectCommand.java
@@ -1,0 +1,89 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import static org.apache.commons.lang3.Validate.notBlank;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+
+/**
+ * A command that identifies project from provided value. The value could be project ID or alias.
+ * The command will handle prefixed values as well.<br>
+ * This command is not compatible with pure OpenRefine instance, it will work only with Ontotext
+ * Refine version 1.2 and above.
+ *
+ * @author Antoniy Kunchev
+ */
+public class IdentifyProjectCommand implements RefineCommand<IdentifyProjectResponse> {
+
+  private final String value;
+
+  private IdentifyProjectCommand(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/project-aliases/identify";
+  }
+
+  @Override
+  public IdentifyProjectResponse execute(RefineClient client) throws RefineException {
+    try {
+      HttpUriRequest request = RequestBuilder
+          .get(client.createUri(endpoint()))
+          .addParameter("value", value)
+          .build();
+
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      String error = String.format("Failed to identify project using value: '%s' due to: %s",
+          value,
+          ioe.getMessage());
+      throw new RefineException(error);
+    }
+  }
+
+  @Override
+  public IdentifyProjectResponse handleResponse(HttpResponse response) throws IOException {
+    if (HttpStatus.SC_OK != response.getStatusLine().getStatusCode()) {
+      throw new RefineException(response.getStatusLine().getReasonPhrase());
+    }
+
+    try (InputStream is = response.getEntity().getContent()) {
+      return new ObjectMapper().readValue(is, IdentifyProjectResponse.class);
+    }
+  }
+
+  /**
+   * Builder for the {@link IdentifyProjectCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String value;
+
+    public Builder setValue(String value) {
+      this.value = value;
+      return this;
+    }
+
+    /**
+     * Validates the provided data and builds the command.
+     *
+     * @return the command
+     */
+    public IdentifyProjectCommand build() {
+      notBlank(value, "The 'value' argument should not be blank.");
+      return new IdentifyProjectCommand(value);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectResponse.java
@@ -1,0 +1,36 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import java.util.Set;
+
+/**
+ * Represents the response from the {@link IdentifyProjectCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+public class IdentifyProjectResponse {
+
+  private long identifier;
+  private String original;
+  private Set<String> aliases;
+  private String prefix;
+
+  IdentifyProjectResponse() {
+    // default
+  }
+
+  public long getIdentifier() {
+    return identifier;
+  }
+
+  public String getOriginal() {
+    return original;
+  }
+
+  public Set<String> getAliases() {
+    return aliases;
+  }
+
+  public String getPrefix() {
+    return prefix;
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommand.java
@@ -1,0 +1,135 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ontotext.refine.client.RefineClient;
+import com.ontotext.refine.client.command.RefineCommand;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.StringEntity;
+
+/**
+ * A command for updating alias data for a given project. The command can add and/or remove multiple
+ * aliases with one execution.<br>
+ * This command is not compatible with pure OpenRefine instance, it will work only with Ontotext
+ * Refine version 1.2 and above.
+ *
+ * @author Antoniy Kunchev
+ */
+public class UpdateProjectAliasesCommand implements RefineCommand<UpdateProjectAliasesResponse> {
+
+  private final String project;
+  private final String[] add;
+  private final String[] remove;
+
+  private UpdateProjectAliasesCommand(String project, String[] add, String[] remove) {
+    this.project = project;
+    this.add = add;
+    this.remove = remove;
+  }
+
+  @Override
+  public String endpoint() {
+    return "/project-aliases";
+  }
+
+  @Override
+  public UpdateProjectAliasesResponse execute(RefineClient client) throws RefineException {
+    try {
+      HttpUriRequest request = RequestBuilder
+          .post(client.createUri(endpoint()))
+          .setEntity(new StringEntity(buildPayload().asText(), UTF_8))
+          .build();
+
+      return client.execute(request, this);
+    } catch (IOException ioe) {
+      String error = String.format(
+          "Failed to update the alias data of project: '%s' due to: %s",
+          project,
+          ioe.getMessage());
+      throw new RefineException(error);
+    }
+  }
+
+  private JsonNode buildPayload() {
+    ObjectNode entity = JsonNodeFactory.instance.objectNode().put("project", project);
+    addIfNotNull(add, "added", entity);
+    addIfNotNull(remove, "removed", entity);
+    return entity;
+  }
+
+  private void addIfNotNull(String[] values, String key, ObjectNode entity) {
+    if (values == null) {
+      return;
+    }
+
+    ArrayNode array = JsonNodeFactory.instance.arrayNode();
+    for (String elem : values) {
+      array.add(elem);
+    }
+
+    entity.set(key, array);
+  }
+
+  @Override
+  public UpdateProjectAliasesResponse handleResponse(HttpResponse response) throws IOException {
+    StatusLine statusLine = response.getStatusLine();
+    if (HttpStatus.SC_OK == statusLine.getStatusCode()) {
+      return UpdateProjectAliasesResponse.ok();
+    }
+    return UpdateProjectAliasesResponse.error(statusLine.getReasonPhrase());
+  }
+
+  /**
+   * Builder for the {@link UpdateProjectAliasesCommand}.
+   *
+   * @author Antoniy Kunchev
+   */
+  public static class Builder {
+
+    private String project;
+    private String[] add;
+    private String[] remove;
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setAdd(String... add) {
+      this.add = add;
+      return this;
+    }
+
+    public Builder setRemove(String... remove) {
+      this.remove = remove;
+      return this;
+    }
+
+    /**
+     * Validates the input data and builds the {@link UpdateProjectAliasesCommand}.
+     *
+     * @return a command
+     */
+    public UpdateProjectAliasesCommand build() {
+      Validate.notBlank(project, "Missing 'project' argument");
+
+      if (ArrayUtils.isEmpty(add) && ArrayUtils.isEmpty(remove)) {
+        throw new IllegalArgumentException("Provide alias(es) to add or remove.");
+      }
+
+      return new UpdateProjectAliasesCommand(project, add, remove);
+    }
+  }
+}

--- a/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesResponse.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesResponse.java
@@ -1,0 +1,35 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import com.ontotext.refine.client.RefineResponse;
+import com.ontotext.refine.client.ResponseCode;
+
+/**
+ * Represents the response from the {@link UpdateProjectAliasesCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+public class UpdateProjectAliasesResponse extends RefineResponse {
+
+  private UpdateProjectAliasesResponse(ResponseCode code, String message) {
+    super(code, message);
+  }
+
+  /**
+   * Creates an successful response instance.
+   *
+   * @return response with code OK
+   */
+  static UpdateProjectAliasesResponse ok() {
+    return new UpdateProjectAliasesResponse(ResponseCode.OK, null);
+  }
+
+  /**
+   * Creates an error response instance.
+   *
+   * @param message provides details for the cause of the error
+   * @return response with code ERROR and details for the cause
+   */
+  static UpdateProjectAliasesResponse error(String message) {
+    return new UpdateProjectAliasesResponse(ResponseCode.ERROR, message);
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/BaseCommandTest.java
@@ -24,7 +24,7 @@ import org.mockito.MockitoAnnotations;
 public abstract class BaseCommandTest<T, R extends RefineCommand<T>> {
 
   protected static final String PROJECT_ID = "1234567890987";
-  protected static final String BASE_URI = "http://localhost:1937/";
+  protected static final String BASE_URI = "http://localhost:1937";
 
   @Mock
   protected RefineClient client;

--- a/src/test/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/project/aliases/IdentifyProjectCommandTest.java
@@ -1,0 +1,102 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+/**
+ * Test for {@link IdentifyProjectCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class IdentifyProjectCommandTest
+    extends BaseCommandTest<IdentifyProjectResponse, IdentifyProjectCommand> {
+
+  @Captor
+  private ArgumentCaptor<HttpUriRequest> requestCaptor;
+
+  private String value;
+
+  @BeforeEach
+  void defaultSetup() {
+    value = PROJECT_ID;
+  }
+
+  @Override
+  protected IdentifyProjectCommand command() {
+    return RefineCommands.identifyProject().setValue(value).build();
+  }
+
+  @Override
+  protected String getTestDir() {
+    return "project-aliases/";
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUri(anyString());
+    verify(client).execute(requestCaptor.capture(), any());
+
+    HttpUriRequest request = requestCaptor.getValue();
+
+    assertEquals("GET", request.getMethod());
+
+    assertEquals(
+        BASE_URI + "/project-aliases/identify?value=" + PROJECT_ID,
+        request.getURI().toString());
+  }
+
+  @Test
+  void execute_error() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exception =
+        assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Failed to identify project using value: '" + PROJECT_ID + "' due to: Test error",
+        exception.getMessage());
+  }
+
+  @Test
+  void handleResponse_successful() throws IOException {
+    IdentifyProjectResponse response =
+        command().handleResponse(okResponse(loadResource("identifyProject_response.json")));
+
+    assertNotNull(response);
+    assertEquals(Long.valueOf(PROJECT_ID), response.getIdentifier());
+    assertEquals("ontorefine:test-alias", response.getOriginal());
+    assertEquals("test-alias", response.getAliases().iterator().next());
+    assertEquals("ontorefine", response.getPrefix());
+  }
+
+  @Test
+  void handleResponse_unexpectedStatusCode() throws IOException {
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getStatusLine())
+        .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "NOT FOUND"));
+
+    assertThrows(RefineException.class, () -> command().handleResponse(response));
+  }
+}

--- a/src/test/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommandTest.java
@@ -1,0 +1,104 @@
+package com.ontotext.refine.client.command.project.aliases;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ontotext.refine.client.ResponseCode;
+import com.ontotext.refine.client.command.BaseCommandTest;
+import com.ontotext.refine.client.command.RefineCommands;
+import com.ontotext.refine.client.exceptions.RefineException;
+import java.io.IOException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+
+/**
+ * Test for {@link UpdateProjectAliasesCommand}.
+ *
+ * @author Antoniy Kunchev
+ */
+class UpdateProjectAliasesCommandTest
+    extends BaseCommandTest<UpdateProjectAliasesResponse, UpdateProjectAliasesCommand> {
+
+  @Captor
+  private ArgumentCaptor<HttpUriRequest> requestCaptor;
+
+  private String project;
+  private String[] add;
+  private String[] remove;
+
+  @BeforeEach
+  void beforeEach() {
+    project = PROJECT_ID;
+    add = new String[] {"added-test-alias"};
+    remove = new String[] {"removed-test-alias"};
+  }
+
+  @Override
+  protected UpdateProjectAliasesCommand command() {
+    return RefineCommands
+        .updateProjectAliases()
+        .setProject(project)
+        .setAdd(add)
+        .setRemove(remove)
+        .build();
+  }
+
+  @Test
+  void execute_successful() throws IOException {
+    assertDoesNotThrow(() -> command().execute(client));
+
+    verify(client).createUri(anyString());
+    verify(client).execute(requestCaptor.capture(), any());
+
+    HttpUriRequest request = requestCaptor.getValue();
+
+    assertEquals("POST", request.getMethod());
+
+    assertEquals(BASE_URI + "/project-aliases", request.getURI().toString());
+
+    // TODO: can check the request payload, but it will require type casting and other nasty hacks
+  }
+
+  @Test
+  void execute_error() throws IOException {
+    when(client.execute(any(), any())).thenThrow(new IOException("Test error"));
+
+    RefineException exception =
+        assertThrows(RefineException.class, () -> command().execute(client));
+
+    assertEquals(
+        "Failed to update the alias data of project: '" + PROJECT_ID + "' due to: Test error",
+        exception.getMessage());
+  }
+
+  @Test
+  void handleResponse_successful() throws IOException {
+    UpdateProjectAliasesResponse response = command().handleResponse(okResponse(null));
+
+    assertEquals(ResponseCode.OK, response.getCode());
+  }
+
+  @Test
+  void handleResponse_unsuccessful() throws IOException {
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getStatusLine())
+        .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "NOT FOUND"));
+
+    UpdateProjectAliasesResponse updateResponse = command().handleResponse(response);
+
+    assertEquals(ResponseCode.ERROR, updateResponse.getCode());
+    assertEquals("NOT FOUND", updateResponse.getMessage());
+  }
+}

--- a/src/test/resources/project-aliases/identifyProject_response.json
+++ b/src/test/resources/project-aliases/identifyProject_response.json
@@ -1,0 +1,8 @@
+{
+  "identifier": 1234567890987,
+  "original": "ontorefine:test-alias",
+  "aliases": [
+    "test-alias"
+  ],
+  "prefix": "ontorefine"
+}


### PR DESCRIPTION
Introduces commands related to the project aliases functionality

- Introduced command for identifying project by specific value, where it
can be project id or alias. The command works with prefixed values as
well.
  The result from the command is a JSON object, containing the project
id, aliases (if any), the prefix (if any) and the original value that
was used for the request (for convenience).

- Introduced command for updating the alias(es) of an project. The
command can add or/and remove alias(es) for specified project. It can
work with multiple values for the operations.


Both commands are related to the new functionality introduced recently
in the Ontotext Refine (OR). It allows some of the functionalities to
refer to a project by specifically assigned value(s) called alias(es).
The commands will work only with OR version 1.2 and above.

---
Fixes an issues with the options for the projects creation command

- Changed the way the `options` are provided to the create project
request. This was necessary, because OpenRefine expects and handles
them, only if they are passed as query parameters.