### PR TITLE
Project aliases fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,17 +60,17 @@
         <maven.resources.plugin.version>3.3.0</maven.resources.plugin.version>
         <maven.checkstyle.plugin.version>3.2.0</maven.checkstyle.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M7</maven.surefire.plugin.version>
-        <dependency.check.plugin.version>7.3.2</dependency.check.plugin.version>
+        <dependency.check.plugin.version>7.4.4</dependency.check.plugin.version>
         <jacoco.version>0.8.8</jacoco.version>
 
-        <httpcomponents.version>4.5.13</httpcomponents.version>
+        <httpcomponents.version>4.5.14</httpcomponents.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.io.version>2.11.0</commons.io.version>
         <jackson.databind.version>2.14.1</jackson.databind.version>
-        <rdf4j.version>4.2.1</rdf4j.version>
+        <rdf4j.version>4.2.2</rdf4j.version>
 
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <mockito.version>4.9.0</mockito.version>
+        <mockito.version>4.11.0</mockito.version>
         <testcontainers.version>1.17.6</testcontainers.version>
         <e2e.graphdb.docker.image>ontotext/graphdb:10.0.0-M1</e2e.graphdb.docker.image>
 

--- a/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommand.java
+++ b/src/main/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommand.java
@@ -1,6 +1,6 @@
 package com.ontotext.refine.client.command.project.aliases;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -12,6 +12,7 @@ import com.ontotext.refine.client.exceptions.RefineException;
 import java.io.IOException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
@@ -49,7 +50,8 @@ public class UpdateProjectAliasesCommand implements RefineCommand<UpdateProjectA
     try {
       HttpUriRequest request = RequestBuilder
           .post(client.createUri(endpoint()))
-          .setEntity(new StringEntity(buildPayload().asText(), UTF_8))
+          .setEntity(new StringEntity(buildPayload().toString(), APPLICATION_JSON))
+          .setHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON.getMimeType())
           .build();
 
       return client.execute(request, this);

--- a/src/test/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommandTest.java
+++ b/src/test/java/com/ontotext/refine/client/command/project/aliases/UpdateProjectAliasesCommandTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.ontotext.refine.client.ResponseCode;
 import com.ontotext.refine.client.command.BaseCommandTest;
 import com.ontotext.refine.client.command.RefineCommands;
@@ -17,6 +19,8 @@ import java.io.IOException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,9 +100,13 @@ class UpdateProjectAliasesCommandTest
     when(response.getStatusLine())
         .thenReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, 404, "NOT FOUND"));
 
+    ObjectNode json = JsonNodeFactory.instance.objectNode().put("message", "Test error");
+    when(response.getEntity())
+        .thenReturn(new StringEntity(json.toString(), ContentType.APPLICATION_JSON));
+
     UpdateProjectAliasesResponse updateResponse = command().handleResponse(response);
 
     assertEquals(ResponseCode.ERROR, updateResponse.getCode());
-    assertEquals("NOT FOUND", updateResponse.getMessage());
+    assertEquals("Test error", updateResponse.getMessage());
   }
 }


### PR DESCRIPTION
Fixes the building of the request for update project aliases command

- Added missing information about the content type of the entity. By
default the content type is text, but the expected payload for the
endpoint is JSON.

  Also fixed the serialization of the payload. The `asText()` method was
producing empty array as result.

---
Fixes the propagation of the error messages for update aliases command

- Fixed the propagation of the errors from the update aliases command.
The actual messages are set in the response entity as part of the JSON
with the details that the server returns.

----
Updates related to project import options and third party dependencies

- Unwrapped the project import options, before adding them as query
parameters to the request.
- Updated the versions of some third party dependencies.